### PR TITLE
feat: AccompanyComment Entity 구현

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/comment/entity/AccompanyComment.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/entity/AccompanyComment.java
@@ -1,0 +1,50 @@
+package connectripbe.connectrip_be.comment.entity;
+
+import connectripbe.connectrip_be.global.entity.BaseEntity;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "accompany_comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AccompanyComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity memberEntity;  // 사용자 아이디 (외래키)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "accompany_post_id", nullable = false)
+    private AccompanyPostEntity accompanyPostEntity;  // 동행 아이디 (외래키)
+
+    @Column(nullable = false)
+    private String content;  // 내용
+
+    @Column(nullable = false)
+    private LocalDateTime createdDate;  // 생성 일자
+
+    @Column(nullable = false)
+    private LocalDateTime modifiedDate;  // 수정 일자
+
+    @Column
+    private LocalDateTime deletedDate;  // 삭제 일자 (NULL 허용)
+
+    public AccompanyComment(MemberEntity memberEntity, AccompanyPostEntity accompanyPostEntity, String content) {
+        this.memberEntity = memberEntity;
+        this.accompanyPostEntity = accompanyPostEntity;
+        this.content = content;
+        this.createdDate = LocalDateTime.now();
+        this.modifiedDate = LocalDateTime.now();
+    }
+}


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 댓글 기능을 위한 엔티티 정의

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- `AccompanyComment` 엔티티 생성
  - 사용자(`MemberEntity`)와 게시글(`AccompanyPostEntity`)과의 관계 설정
  - 댓글 내용, 생성 일자, 수정 일자, 삭제 일자 필드 추가

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 