### PR TITLE
feat: 해당 동행 참여자 목록 조회 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/accompany_member/dto/AccompanyMemberResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_member/dto/AccompanyMemberResponse.java
@@ -1,0 +1,22 @@
+package connectripbe.connectrip_be.accompany_member.dto;
+
+import connectripbe.connectrip_be.accompany_member.entity.AccompanyMemberEntity;
+import lombok.Builder;
+
+@Builder
+public record AccompanyMemberResponse(
+        Long memberId,
+        String nickname,
+        String profileImagePath,
+        String status
+) {
+
+      public static AccompanyMemberResponse fromEntity(AccompanyMemberEntity accompanyMember) {
+            return AccompanyMemberResponse.builder()
+                    .memberId(accompanyMember.getMember().getId())
+                    .nickname(accompanyMember.getMember().getNickname())
+                    .profileImagePath(accompanyMember.getMember().getProfileImagePath())
+                    .status(accompanyMember.getStatus().getDisplayName())
+                    .build();
+      }
+}

--- a/src/main/java/connectripbe/connectrip_be/accompany_member/entity/AccompanyMemberEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_member/entity/AccompanyMemberEntity.java
@@ -1,0 +1,56 @@
+package connectripbe.connectrip_be.accompany_member.entity;
+
+import connectripbe.connectrip_be.accompany_member.entity.type.AccompanyMemberStatus;
+import connectripbe.connectrip_be.global.entity.BaseEntity;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity(name = "accompany_member")
+public class AccompanyMemberEntity extends BaseEntity {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long id;
+
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "member_id")
+      private MemberEntity member;
+
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "accompany_post_id")
+      private AccompanyPostEntity accompanyPost;
+
+      @Enumerated(EnumType.STRING)
+      @Builder.Default
+      @Column(name = "status",nullable = false)
+      private AccompanyMemberStatus status = AccompanyMemberStatus.ACTIVE;
+
+
+      /**
+       * 채팅방에서 회원이 나갈 때 사용
+       */
+      public void exitAccompany() {
+            this.status = AccompanyMemberStatus.EXIT;
+      }
+
+
+
+}

--- a/src/main/java/connectripbe/connectrip_be/accompany_member/entity/type/AccompanyMemberStatus.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_member/entity/type/AccompanyMemberStatus.java
@@ -1,0 +1,14 @@
+package connectripbe.connectrip_be.accompany_member.entity.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AccompanyMemberStatus {
+
+      ACTIVE("채팅방 활동 중"),
+      EXIT("채팅방 나감");
+
+    private final String displayName;
+}

--- a/src/main/java/connectripbe/connectrip_be/accompany_member/repository/AccompanyMemberRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_member/repository/AccompanyMemberRepository.java
@@ -1,0 +1,13 @@
+package connectripbe.connectrip_be.accompany_member.repository;
+
+
+import connectripbe.connectrip_be.accompany_member.entity.AccompanyMemberEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccompanyMemberRepository extends JpaRepository<AccompanyMemberEntity, Long> {
+
+      List<AccompanyMemberEntity> findAllByAccompanyPost_Id(Long accompanyPostId);
+}

--- a/src/main/java/connectripbe/connectrip_be/accompany_member/service/AccompanyMemberService.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_member/service/AccompanyMemberService.java
@@ -1,0 +1,16 @@
+package connectripbe.connectrip_be.accompany_member.service;
+
+import connectripbe.connectrip_be.accompany_member.dto.AccompanyMemberResponse;
+import java.util.List;
+
+public interface AccompanyMemberService {
+
+      // 해당 동행 참여자 목록 조회
+      List<AccompanyMemberResponse> getAccompanyMemberList(Long accompanyId);
+
+
+}
+
+// 해당 동행 참여자 목록 조회
+// 내 동행 목록 리스트
+

--- a/src/main/java/connectripbe/connectrip_be/accompany_member/service/impl/AccompanyMemberServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_member/service/impl/AccompanyMemberServiceImpl.java
@@ -1,0 +1,37 @@
+package connectripbe.connectrip_be.accompany_member.service.impl;
+
+import connectripbe.connectrip_be.accompany_member.dto.AccompanyMemberResponse;
+import connectripbe.connectrip_be.accompany_member.entity.AccompanyMemberEntity;
+import connectripbe.connectrip_be.accompany_member.repository.AccompanyMemberRepository;
+import connectripbe.connectrip_be.accompany_member.service.AccompanyMemberService;
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AccompanyMemberServiceImpl implements AccompanyMemberService {
+      private final AccompanyMemberRepository accompanyMemberRepository;
+
+      /**
+       * 주어진 동행 게시물 ID(accompanyPostId)에 연관된 모든 참여자 목록을 조회하여 반환.
+       * 해당 게시물에 참여한 회원들의 ID, 닉네임, 프로필 이미지 경로, 해당 채팅방에서의 상태를 포함하는
+       * AccompanyMemberResponse 리스트를 반환.
+       *
+       * @param accompanyPostId 조회하고자 하는 동행 게시물의 ID
+       * @return 동행 게시물에 참여한 모든 회원의 정보를 담은 AccompanyMemberResponse 리스트
+       * @throws GlobalException 요청한 동행 게시물 ID가 유효하지 않을 경우 발생.
+       */
+      @Override
+      public List<AccompanyMemberResponse> getAccompanyMemberList(Long accompanyPostId) {
+
+            List<AccompanyMemberEntity> accompanyMember = accompanyMemberRepository.findAllByAccompanyPost_Id(
+                            accompanyPostId);
+
+            return accompanyMember.stream()
+                    .map(AccompanyMemberResponse::fromEntity).toList();
+      }
+}

--- a/src/main/java/connectripbe/connectrip_be/accompany_member/web/AccompanyMemberController.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_member/web/AccompanyMemberController.java
@@ -1,0 +1,24 @@
+package connectripbe.connectrip_be.accompany_member.web;
+
+import connectripbe.connectrip_be.accompany_member.dto.AccompanyMemberResponse;
+import connectripbe.connectrip_be.accompany_member.service.AccompanyMemberService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/accompany")
+@RequiredArgsConstructor
+public class AccompanyMemberController {
+
+      private final AccompanyMemberService accompanyMemberService;
+
+      @GetMapping("{accompanyPostId}/members")
+      public ResponseEntity<List<AccompanyMemberResponse>> getAccompanyMemberList(@PathVariable Long accompanyPostId) {
+            return ResponseEntity.ok(accompanyMemberService.getAccompanyMemberList(accompanyPostId));
+      }
+}

--- a/src/test/java/connectripbe/connectrip_be/accompany_member/service/impl/AccompanyMemberServiceImplTest.java
+++ b/src/test/java/connectripbe/connectrip_be/accompany_member/service/impl/AccompanyMemberServiceImplTest.java
@@ -1,0 +1,81 @@
+package connectripbe.connectrip_be.accompany_member.service.impl;
+
+import connectripbe.connectrip_be.accompany_member.dto.AccompanyMemberResponse;
+import connectripbe.connectrip_be.accompany_member.entity.AccompanyMemberEntity;
+import connectripbe.connectrip_be.accompany_member.entity.type.AccompanyMemberStatus;
+import connectripbe.connectrip_be.accompany_member.repository.AccompanyMemberRepository;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class AccompanyMemberServiceImplTest {
+
+      @Mock
+      private AccompanyMemberRepository accompanyMemberRepository;
+
+      @InjectMocks
+      private AccompanyMemberServiceImpl accompanyMemberService;
+
+      @BeforeEach
+      void setUp() {
+            MockitoAnnotations.openMocks(this);
+      }
+
+      @Test
+      void testGetAccompanyMemberList() {
+            // Given
+            Long accompanyPostId = 1L;
+            MemberEntity member1 = MemberEntity.builder()
+                    .id(1L)
+                    .nickname("nickname1")
+                    .profileImagePath("path/to/profile1")
+                    .build();
+            MemberEntity member2 = MemberEntity.builder()
+                    .id(2L)
+                    .nickname("nickname2")
+                    .profileImagePath("path/to/profile2")
+                    .build();
+
+            AccompanyPostEntity accompanyPost = AccompanyPostEntity.builder()
+                    .id(accompanyPostId)
+                    .build();
+
+            AccompanyMemberEntity accompanyMember1 = AccompanyMemberEntity.builder()
+                    .id(1L)
+                    .member(member1)
+                    .accompanyPost(accompanyPost)
+                    .status(AccompanyMemberStatus.ACTIVE)
+                    .build();
+
+            AccompanyMemberEntity accompanyMember2 = AccompanyMemberEntity.builder()
+                    .id(2L)
+                    .member(member2)
+                    .accompanyPost(accompanyPost)
+                    .status(AccompanyMemberStatus.ACTIVE)
+                    .build();
+
+            List<AccompanyMemberEntity> accompanyMemberList = Arrays.asList(accompanyMember1, accompanyMember2);
+
+            when(accompanyMemberRepository.findAllByAccompanyPost_Id(accompanyPostId)).thenReturn(accompanyMemberList);
+
+            // When
+            List<AccompanyMemberResponse> result = accompanyMemberService.getAccompanyMemberList(accompanyPostId);
+
+            // Then
+            assertEquals(2, result.size());
+            assertEquals("nickname1", result.get(0).nickname());
+            assertEquals("nickname2", result.get(1).nickname());
+      }
+
+
+}


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
-  동행 게시물에 참여한 회원 목록을 조회할 수 있는 API가 필요.

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요.
- `AccompanyMemberResponse` DTO 추가: 동행 게시물에 참여한 회원의 정보를 반환하기 위한 DTO입니다.
- `AccompanyMemberEntity` 엔티티 추가: 동행 게시물과 회원 간의 관계를 나타내는 엔티티입니다.
- `AccompanyMemberRepository` 추가: 동행 게시물과 회원 간의 관계를 조회할 수 있는 리포지토리입니다.
- `AccompanyMemberService` 인터페이스 및 `AccompanyMemberServiceImpl` 구현체 추가: 동행 게시물에 참여한 회원들의 목록을 조회하는 로직을 처리합니다.
- `AccompanyMemberController` 추가: API 요청을 처리하여 동행 게시물에 참여한 회원 목록을 반환합니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드 작성
- [x] API 테스트