### PR TITLE
[임시] 카카오 로그인 후 인증을 JSON으로 받지 않고, 쿠키로 받도록 변경

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/auth/kakao/service/KakaoService.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/kakao/service/KakaoService.java
@@ -47,7 +47,7 @@ public class KakaoService {
    * @return 로그인 처리 결과
    */
 
-  public Object kakaoLogin(String code) {
+  public TokenDto kakaoLogin(String code) {
     // 카카오 서버로부터 액세스 토큰을 받아온다.
     KakaoTokenApiResponse token = kakaoApi.getToken(grant_type, client_id, redirect_uri, code);
     String accessToken = token.getAccess_token();

--- a/src/main/java/connectripbe/connectrip_be/auth/web/AuthController.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/web/AuthController.java
@@ -8,6 +8,8 @@ import connectripbe.connectrip_be.auth.dto.SignUpDto;
 import connectripbe.connectrip_be.auth.jwt.dto.TokenDto;
 import connectripbe.connectrip_be.auth.kakao.service.KakaoService;
 import connectripbe.connectrip_be.auth.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,49 +25,69 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 
-      private final AuthService authService;
-      // private final MailService mailService;
-      private final KakaoService kakaoService;
+    private final AuthService authService;
+    // private final MailService mailService;
+    private final KakaoService kakaoService;
 
 
-      @PostMapping(path = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
-              produces = MediaType.APPLICATION_JSON_VALUE)
-      public ResponseEntity<SignUpDto> signUp(@RequestPart("request") SignUpDto request,
-              @RequestPart(name = "image", required = false) MultipartFile image) {
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(authService.signUp(request, image));
-      }
+    @PostMapping(path = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<SignUpDto> signUp(@RequestPart("request") SignUpDto request,
+                                            @RequestPart(name = "image", required = false) MultipartFile image) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(authService.signUp(request, image));
+    }
 
-      @PostMapping(path = "/signin", consumes = MediaType.APPLICATION_JSON_VALUE,
-              produces = MediaType.APPLICATION_JSON_VALUE)
-      public ResponseEntity<TokenDto> signIn(@RequestBody SignInDto request) {
-            return ResponseEntity.ok(authService.signIn(request));
-      }
+    @PostMapping(path = "/signin", consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<TokenDto> signIn(@RequestBody SignInDto request) {
+        return ResponseEntity.ok(authService.signIn(request));
+    }
 
-      @PostMapping(path = "/logout", consumes = MediaType.APPLICATION_JSON_VALUE,
-              produces = MediaType.APPLICATION_JSON_VALUE)
-      public ResponseEntity<?> logout(@RequestBody LogoutDto request) {
+    @PostMapping(path = "/logout", consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> logout(@RequestBody LogoutDto request) {
 
-            authService.logout(request);
-            return ResponseEntity.status(HttpStatus.OK).body("로그아웃 성공");
-      }
+        authService.logout(request);
+        return ResponseEntity.status(HttpStatus.OK).body("로그아웃 성공");
+    }
 
-      @PostMapping(path = "/reissue", consumes = MediaType.APPLICATION_JSON_VALUE,
-              produces = MediaType.APPLICATION_JSON_VALUE)
-      public ResponseEntity<TokenDto> reissue(@Valid @RequestBody ReissueDto request) {
+    @PostMapping(path = "/reissue", consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<TokenDto> reissue(@Valid @RequestBody ReissueDto request) {
 
-            return ResponseEntity.ok(authService.reissue(request));
-      }
+        return ResponseEntity.ok(authService.reissue(request));
+    }
 
+    // fixme-noah: 임시 구현
+    @GetMapping("/redirected/kakao")
+    public void kakaoLogin(@RequestParam("code") String code, HttpServletResponse httpServletResponse) throws IOException {
+        TokenDto tokenDto = kakaoService.kakaoLogin(code);
 
-      @GetMapping("/redirected/kakao")
-      public ResponseEntity<?> kakaoLogin(@RequestParam("code") String code) {
-            return ResponseEntity.ok(kakaoService.kakaoLogin(code));
-      }
+        Cookie refreshTokenCookie = new Cookie("refresh_token", tokenDto.getRefreshToken());
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setMaxAge(Math.toIntExact(tokenDto.getRefreshTokenExpireTime()));
+
+        httpServletResponse.addCookie(refreshTokenCookie);
+
+        Cookie accessTokenCookie = new Cookie("access_token", tokenDto.getAccessToken());
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setMaxAge(Math.toIntExact(tokenDto.getAccessTokenExpireTime()));
+
+        httpServletResponse.addCookie(accessTokenCookie);
+
+        httpServletResponse.sendRedirect("http://localhost:3000/accompany");
+    }
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- JSON을 통한 토큰값 노출, 수정 방지

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 인증 토큰의 전달 방식을 JSON Body에서 Cookie로 변경

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 