### PR TITLE
헤더 사용자 프로필 이미지, 닉네임 조회 API, 첫 로그인 시 기본 정보 입력 API 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
 
     // Member, 사용자
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    DUPLICATE_MEMBER_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
+
     // info-noah: 세분화 시 변경될 수 있음
     MEMBER_NOT_OWNER_EXCEPTION(HttpStatus.FORBIDDEN, "소유자가 아닙니다."),
 

--- a/src/main/java/connectripbe/connectrip_be/member/dto/FirstUpdateMemberRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/member/dto/FirstUpdateMemberRequest.java
@@ -1,0 +1,11 @@
+package connectripbe.connectrip_be.member.dto;
+
+
+import java.time.LocalDateTime;
+
+public record FirstUpdateMemberRequest(
+        String nickname,
+        LocalDateTime birthDate,
+        String gender
+) {
+}

--- a/src/main/java/connectripbe/connectrip_be/member/dto/MemberHeaderInfoResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/member/dto/MemberHeaderInfoResponse.java
@@ -1,0 +1,19 @@
+package connectripbe.connectrip_be.member.dto;
+
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import lombok.Builder;
+
+@Builder
+public record MemberHeaderInfoResponse(
+        Long memberId,
+        String profileImagePath,
+        String nickname
+) {
+    public static MemberHeaderInfoResponse fromEntity(MemberEntity memberEntity) {
+        return MemberHeaderInfoResponse.builder()
+                .memberId(memberEntity.getId())
+                .profileImagePath(memberEntity.getProfileImagePath())
+                .nickname(memberEntity.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/member/entity/MemberEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/member/entity/MemberEntity.java
@@ -6,14 +6,11 @@ import connectripbe.connectrip_be.member.entity.type.MemberRoleType;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
 import jakarta.persistence.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
 
 @Entity
 @Getter
@@ -45,8 +42,8 @@ public class MemberEntity extends BaseEntity {
     @Column(name = "description")
     private String description; // 자기소개
 
-    @Column(name = "age")
-    private String age; // 나이
+    @Column(name = "birth_date")
+    private LocalDateTime birthDate;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "login_type", nullable = false, length = 10)
@@ -59,4 +56,10 @@ public class MemberEntity extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "memberEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AccompanyPostEntity> accompanyPostEntities = new ArrayList<>();
+
+    public void firstUpdate(String nickname, LocalDateTime birthDate, String gender) {
+        this.nickname = nickname;
+        this.birthDate = birthDate;
+        this.gender = gender;
+    }
 }

--- a/src/main/java/connectripbe/connectrip_be/member/exception/DuplicateMemberNicknameException.java
+++ b/src/main/java/connectripbe/connectrip_be/member/exception/DuplicateMemberNicknameException.java
@@ -1,0 +1,11 @@
+package connectripbe.connectrip_be.member.exception;
+
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+
+public class DuplicateMemberNicknameException extends GlobalException {
+
+    public DuplicateMemberNicknameException() {
+        super(ErrorCode.DUPLICATE_MEMBER_NICKNAME);
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/member/service/MemberService.java
+++ b/src/main/java/connectripbe/connectrip_be/member/service/MemberService.java
@@ -1,0 +1,8 @@
+package connectripbe.connectrip_be.member.service;
+
+import connectripbe.connectrip_be.member.dto.MemberHeaderInfoResponse;
+
+public interface MemberService {
+
+    MemberHeaderInfoResponse getMemberHeaderInfo(String email);
+}

--- a/src/main/java/connectripbe/connectrip_be/member/service/MemberService.java
+++ b/src/main/java/connectripbe/connectrip_be/member/service/MemberService.java
@@ -1,8 +1,12 @@
 package connectripbe.connectrip_be.member.service;
 
+import connectripbe.connectrip_be.member.dto.FirstUpdateMemberRequest;
 import connectripbe.connectrip_be.member.dto.MemberHeaderInfoResponse;
 
 public interface MemberService {
 
     MemberHeaderInfoResponse getMemberHeaderInfo(String email);
+
+    // fixme-noah: 추후 달라지면 response 분리
+    MemberHeaderInfoResponse getFirstUpdateMemberResponse(String email, FirstUpdateMemberRequest request);
 }

--- a/src/main/java/connectripbe/connectrip_be/member/service/MemberServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/member/service/MemberServiceImpl.java
@@ -1,11 +1,14 @@
 package connectripbe.connectrip_be.member.service;
 
+import connectripbe.connectrip_be.member.dto.FirstUpdateMemberRequest;
 import connectripbe.connectrip_be.member.dto.MemberHeaderInfoResponse;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.member.exception.DuplicateMemberNicknameException;
 import connectripbe.connectrip_be.member.exception.NotFoundMemberException;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,5 +27,24 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(NotFoundMemberException::new);
 
         return MemberHeaderInfoResponse.fromEntity(memberEntity);
+    }
+
+    @Transactional
+    @Override
+    public MemberHeaderInfoResponse getFirstUpdateMemberResponse(String email, FirstUpdateMemberRequest request) {
+        MemberEntity memberEntity = memberJpaRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+
+        if (memberJpaRepository.existsByNickname(request.nickname())) {
+            throw new DuplicateMemberNicknameException();
+        }
+
+        memberEntity.firstUpdate(request.nickname(), request.birthDate(), request.gender());
+
+        return MemberHeaderInfoResponse.builder()
+                .memberId(memberEntity.getId())
+                .profileImagePath(memberEntity.getProfileImagePath())
+                .nickname(memberEntity.getNickname())
+                .build();
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/member/service/MemberServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/member/service/MemberServiceImpl.java
@@ -1,0 +1,28 @@
+package connectripbe.connectrip_be.member.service;
+
+import connectripbe.connectrip_be.member.dto.MemberHeaderInfoResponse;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.member.exception.NotFoundMemberException;
+import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberJpaRepository memberJpaRepository;
+
+    /**
+     * 헤더에 사용자 프로필 이미지와 닉네임을 전달하기 위한 메서드
+     *
+     * @author noah(49EHyeon42)
+     */
+    @Override
+    public MemberHeaderInfoResponse getMemberHeaderInfo(String email) {
+        MemberEntity memberEntity = memberJpaRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+
+        return MemberHeaderInfoResponse.fromEntity(memberEntity);
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/member/web/MemberController.java
+++ b/src/main/java/connectripbe/connectrip_be/member/web/MemberController.java
@@ -1,0 +1,22 @@
+package connectripbe.connectrip_be.member.web;
+
+import connectripbe.connectrip_be.auth.config.LoginUser;
+import connectripbe.connectrip_be.member.dto.MemberHeaderInfoResponse;
+import connectripbe.connectrip_be.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    public MemberHeaderInfoResponse getMemberHeaderInfo(@LoginUser String email) {
+        return memberService.getMemberHeaderInfo(email);
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/member/web/MemberController.java
+++ b/src/main/java/connectripbe/connectrip_be/member/web/MemberController.java
@@ -1,12 +1,11 @@
 package connectripbe.connectrip_be.member.web;
 
 import connectripbe.connectrip_be.auth.config.LoginUser;
+import connectripbe.connectrip_be.member.dto.FirstUpdateMemberRequest;
 import connectripbe.connectrip_be.member.dto.MemberHeaderInfoResponse;
 import connectripbe.connectrip_be.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -18,5 +17,10 @@ public class MemberController {
     @GetMapping("/me")
     public MemberHeaderInfoResponse getMemberHeaderInfo(@LoginUser String email) {
         return memberService.getMemberHeaderInfo(email);
+    }
+
+    @PostMapping("/first")
+    public MemberHeaderInfoResponse firstUpdateMember(@LoginUser String email, @RequestBody FirstUpdateMemberRequest request) {
+        return memberService.getFirstUpdateMemberResponse(email, request);
     }
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 헤더 사용자 프로필 이미지 API 추가
- 첫 로그인 시 기본 정보 입력 API 추가

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- member 테이블 컬럼 일부 수정됨

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 