### PR TITLE
feat: 채팅방 관련 기능 및 사용자가 참여한 채팅방 목록 조회 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
@@ -1,0 +1,46 @@
+package connectripbe.connectrip_be.chat.dto;
+
+import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+
+@Builder
+public record ChatRoomListResponse(
+        Long chatRoomId,
+        Long accompanyPostId,
+        String accompanyPostTitle,
+        String accompanyArea,
+        String startDate,
+        String endDate,
+        String lastChatMessage,
+        String lastChatMessageTime
+        ) {
+
+
+      public static ChatRoomListResponse fromEntity(ChatRoomEntity chatRoom){
+            return ChatRoomListResponse.builder()
+                    .chatRoomId(chatRoom.getId())
+                    .accompanyPostId(chatRoom.getAccompanyPost().getId())
+                    .accompanyPostTitle(chatRoom.getAccompanyPost().getTitle())
+                    .accompanyArea(chatRoom.getAccompanyPost().getAccompanyArea().toString())
+                    .startDate(formatToUTC(chatRoom.getAccompanyPost().getStartDate().atStartOfDay()))
+                    .endDate(formatToUTC(chatRoom.getAccompanyPost().getEndDate().atStartOfDay()))
+                    .lastChatMessage(chatRoom.getLastChatMessage())
+                    .lastChatMessageTime(formatToUTC(chatRoom.getLastChatTime()))
+                    .build();
+      }
+
+      private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
+              "yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+      private static String formatToUTC(LocalDateTime dateTime) {
+            if (dateTime == null) {
+                  return null;
+            }
+            return dateTime.atZone(ZoneId.systemDefault())
+                    .withZoneSameInstant(ZoneId.of("UTC"))
+                    .format(UTC_FORMATTER);
+      }
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
@@ -1,0 +1,62 @@
+package connectripbe.connectrip_be.chat.entity;
+
+import connectripbe.connectrip_be.chat.entity.type.ChatRoomType;
+import connectripbe.connectrip_be.global.entity.BaseEntity;
+import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "chat_room")
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+@Builder
+public class ChatRoomEntity extends BaseEntity {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long id;
+
+      @OneToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "accompany_post_id")
+      private AccompanyPostEntity accompanyPost;
+
+      @Enumerated(EnumType.STRING)
+      private ChatRoomType chatRoomType;
+
+      private String lastChatMessage;
+
+      private LocalDateTime lastChatTime;
+
+      @Builder.Default
+      @OneToMany(mappedBy = "chatRoom")
+      private List<ChatRoomMemberEntity> chatRoomMembers = new ArrayList<>();
+
+      /**
+       *  ChatRoomMember 추가 및 양방향 관계 설정 메서드
+       * @param chatRoomMember 채팅참여자 객체
+       */
+      public void addChatRoomMember(ChatRoomMemberEntity chatRoomMember) {
+            this.chatRoomMembers.add(chatRoomMember);
+            chatRoomMember.assignChatRoom(this);
+      }
+
+      //TODO 마지막 채팅 메시지 및 시간 업데이트 메서드
+
+
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomMemberEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomMemberEntity.java
@@ -1,0 +1,61 @@
+package connectripbe.connectrip_be.chat.entity;
+
+import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
+import connectripbe.connectrip_be.global.entity.BaseEntity;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "chat_room_member")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomMemberEntity extends BaseEntity {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long id;
+
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "chat_room_id")
+      private ChatRoomEntity chatRoom;
+
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "member_id")
+      private MemberEntity member;
+
+      @Enumerated(EnumType.STRING)
+      private ChatRoomMemberStatus status;
+
+      // 연관관계 메서드
+      public void assignChatRoom(ChatRoomEntity chatRoomEntity) {
+            this.chatRoom = chatRoomEntity;
+      }
+
+      public void updateStatus(ChatRoomMemberStatus status) {
+            this.status = status;
+      }
+
+      public void exitChatRoom() {
+            this.status = ChatRoomMemberStatus.EXIT;
+      }
+
+      public void activeChatRoom() {
+            this.status = ChatRoomMemberStatus.ACTIVE;
+      }
+
+
+
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/type/ChatRoomMemberStatus.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/type/ChatRoomMemberStatus.java
@@ -1,0 +1,13 @@
+package connectripbe.connectrip_be.chat.entity.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ChatRoomMemberStatus {
+      ACTIVE("활성"),
+      EXIT("나감");
+
+      private final String status;
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/type/ChatRoomType.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/type/ChatRoomType.java
@@ -1,0 +1,16 @@
+package connectripbe.connectrip_be.chat.entity.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ChatRoomType {
+
+      ACTIVE("ACTIVE"),
+      FINISH("FINISH"),
+      DELETE("DELETE")
+      ;
+
+      private final String code;
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
@@ -1,0 +1,14 @@
+package connectripbe.connectrip_be.chat.repository;
+
+import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
+import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMemberEntity, Long> {
+
+      List<ChatRoomMemberEntity> findByMember_Email(String email);
+
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,10 @@
+package connectripbe.connectrip_be.chat.repository;
+
+import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
@@ -1,0 +1,10 @@
+package connectripbe.connectrip_be.chat.service;
+
+import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
+import java.util.List;
+
+public interface ChatRoomService {
+
+      List<ChatRoomListResponse> getChatRoomList(String email);
+
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
@@ -1,0 +1,36 @@
+package connectripbe.connectrip_be.chat.service.impl;
+
+import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
+import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
+import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
+import connectripbe.connectrip_be.chat.service.ChatRoomService;
+
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+
+      private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+      /**
+       * 사용자가 참여한 채팅방 목록을 조회하여 반환하는 메서드. 주어진 사용자의 이메일 주소를 기반으로 해당 사용자가 참여한 모든 채팅방을 조회
+       *
+       * @param email 사용자의 이메일 주소. 이 이메일을 기반으로 해당 사용자가 참여한 채팅방을 조회
+       * @return 사용자가 참여한 채팅방의 목록을 포함하는 `List<ChatRoomListResponse>` 사용자가 참여한 채팅방이 없을 경우 빈 리스트를 반환
+       */
+      @Override
+      public List<ChatRoomListResponse> getChatRoomList(String email) {
+            // 사용자 참여한 모든 ChatRoomMemberEntity 조회
+            List<ChatRoomMemberEntity> chatRoomMembers = chatRoomMemberRepository.findByMember_Email(
+                    email);
+
+            return chatRoomMembers.stream()
+                    .map(member -> ChatRoomListResponse.fromEntity(member.getChatRoom())).toList();
+      }
+
+
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
@@ -1,0 +1,25 @@
+package connectripbe.connectrip_be.chat.web;
+
+import connectripbe.connectrip_be.auth.config.LoginUser;
+import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
+import connectripbe.connectrip_be.chat.service.ChatRoomService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/chatRoom")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+      private final ChatRoomService chatRoomService;
+
+      @GetMapping("/list")
+      public ResponseEntity<List<ChatRoomListResponse>> getChatRoomList(@LoginUser String email) {
+            return ResponseEntity.ok(chatRoomService.getChatRoomList(email));
+      }
+
+}

--- a/src/test/java/connectripbe/connectrip_be/accompany_member/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/connectripbe/connectrip_be/accompany_member/service/impl/ChatRoomServiceImplTest.java
@@ -1,0 +1,80 @@
+package connectripbe.connectrip_be.accompany_member.service.impl;
+
+import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
+import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
+import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
+import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
+import connectripbe.connectrip_be.chat.service.impl.ChatRoomServiceImpl;
+import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import connectripbe.connectrip_be.post.entity.enums.AccompanyArea;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class ChatRoomServiceImplTest {
+
+      @InjectMocks
+      private ChatRoomServiceImpl chatRoomService;
+
+      @Mock
+      private ChatRoomMemberRepository chatRoomMemberRepository;
+
+      @BeforeEach
+      void setUp() {
+            MockitoAnnotations.openMocks(this);
+      }
+
+      @Test
+      @DisplayName("사용자가 참여한 채팅방 목록을 조회하여 반환")
+      void testGetChatRoomList_ReturnsList() {
+            String email = "test@example.com";
+
+            AccompanyPostEntity accompanyPost = AccompanyPostEntity.builder()
+                    .id(1L)
+                    .title("Test Title")
+                    .accompanyArea(AccompanyArea.SEOUL)
+                    .startDate(LocalDate.now())
+                    .endDate(LocalDate.now().plusDays(5))
+                    .build();
+
+            ChatRoomEntity chatRoom = ChatRoomEntity.builder()
+                    .id(1L)
+                    .accompanyPost(accompanyPost)
+                    .build();
+
+            ChatRoomMemberEntity memberEntity = ChatRoomMemberEntity.builder()
+                    .chatRoom(chatRoom)
+                    .build();
+
+            // chatRoomMemberRepository가 특정 이메일에 대한 데이터를 반환하도록 설정
+            when(chatRoomMemberRepository.findByMember_Email(email)).thenReturn(List.of(memberEntity));
+
+            List<ChatRoomListResponse> result = chatRoomService.getChatRoomList(email);
+
+            assertEquals(1, result.size());  // 반환된 리스트의 크기 검증
+            assertEquals(1L, result.get(0).chatRoomId());  // chatRoomId 검증
+            assertEquals(1L, result.get(0).accompanyPostId());  // accompanyPostId 검증
+            assertEquals("Test Title", result.get(0).accompanyPostTitle());  // accompanyPostTitle 검증
+            assertEquals("SEOUL", result.get(0).accompanyArea());  // accompanyArea 검증
+      }
+
+      @Test
+      @DisplayName("채팅방이 없을 경우 빈 리스트 반환")
+      void testGetChatRoomList_ReturnsEmptyListWhenNoRooms() {
+            String email = "test@example.com";
+            when(chatRoomMemberRepository.findByMember_Email(email)).thenReturn(List.of());
+
+            List<ChatRoomListResponse> result = chatRoomService.getChatRoomList(email);
+
+            assertEquals(0, result.size());
+      }
+}


### PR DESCRIPTION
### 제목
feat: 채팅방 관련 기능 및 목록 조회 기능 추가

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 채팅방 및 채팅방 멤버 관리 기능의 부재

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- 채팅방 관련 엔티티 및 상태 관리 기능 추가 (`ChatRoomEntity`, `ChatRoomMemberEntity`, `ChatRoomType`, `ChatRoomMemberStatus`)
- 채팅방 목록 조회 기능 구현 (`ChatRoomListResponse`, `ChatRoomService`, `ChatRoomServiceImpl`)
- 채팅방 목록 조회 API 추가 (`ChatRoomController`)
- 채팅방 관련 서비스 로직에 대한 테스트 코드 추가 (`ChatRoomServiceImplTest`)

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드 작성 및 실행 완료
- [x] API 테스트 완료 