### PR TITLE
feat: 게시물 최신순 정렬 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/post/repository/AccompanyPostRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/post/repository/AccompanyPostRepository.java
@@ -1,10 +1,13 @@
 package connectripbe.connectrip_be.post.repository;
 
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository // 이 인터페이스가 스프링의 리포지토리임을 나타냄
+@Repository
 public interface AccompanyPostRepository extends JpaRepository<AccompanyPostEntity, Long> {
+
+      List<AccompanyPostEntity> findAllByOrderByCreatedAtDesc();
 
 }

--- a/src/main/java/connectripbe/connectrip_be/post/service/AccompanyPostService.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/AccompanyPostService.java
@@ -15,6 +15,7 @@ public interface AccompanyPostService {
     void updateAccompanyPost(String memberEmail, long id, AccompanyPostRequest request);
 
     void deleteAccompanyPost(String memberEmail, long id);
-    // 게시물 전체 리스트 - 페이징 처리
+
+    //TODO 게시물 전체 리스트 - 페이징 처리
     List<AccompanyPostListResponse> accompanyPostList();
 }

--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -98,7 +98,7 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
 
     @Override
     public List<AccompanyPostListResponse> accompanyPostList() {
-        List<AccompanyPostEntity> all =  accompanyPostRepository.findAll();
+        List<AccompanyPostEntity> all =  accompanyPostRepository.findAllByOrderByCreatedAtDesc();
         return all.stream().map(AccompanyPostListResponse::fromEntity).toList();
     }
 

--- a/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
+++ b/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
@@ -7,8 +7,6 @@ import connectripbe.connectrip_be.post.dto.AccompanyPostResponse;
 import connectripbe.connectrip_be.post.service.AccompanyPostService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -52,7 +50,8 @@ public class AccompanyPostController {
             return ResponseEntity.ok().build();
       }
 
-      // fixme-naoh: 나중에 수정
+
+      // 게시물 최신순으로 정렬
       @GetMapping
       public ResponseEntity<List<AccompanyPostListResponse>> listPosts() {
             return ResponseEntity.ok(accompanyPostService.accompanyPostList());


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 동행 게시물 리스트를 최신순으로 정렬하여 제공하는 기능 부재

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- `AccompanyPostRepository`에 게시물 생성일 기준으로 최신순 정렬하는 메서드 추가 (`findAllByOrderByCreatedAtDesc`)
- `AccompanyPostServiceImpl`에서 최신순으로 정렬된 게시물 리스트 반환하도록 수정
- `AccompanyPostController`에서 최신순으로 정렬된 게시물 리스트를 반환하는 API 수정

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 작성 및 실행 완료
- [ ] API 테스트 완료 