### PR TITLE
동행 게시글 상태를 update를 통해 변경하지 않고, 추적할 수 있도록 계속해서 삽입하는 방식으로 변경

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/accompany_status/entity/AccompanyStatusEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_status/entity/AccompanyStatusEntity.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "accompany_status")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class AccompanyStatusEntity extends BaseEntity {

--- a/src/main/java/connectripbe/connectrip_be/accompany_status/entity/AccompanyStatusEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_status/entity/AccompanyStatusEntity.java
@@ -1,6 +1,5 @@
 package connectripbe.connectrip_be.accompany_status.entity;
 
-import connectripbe.connectrip_be.accompany_status.exception.AlreadyFinishedAccompanyStatusException;
 import connectripbe.connectrip_be.global.entity.BaseEntity;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
 import jakarta.persistence.*;
@@ -28,15 +27,5 @@ public class AccompanyStatusEntity extends BaseEntity {
     public AccompanyStatusEntity(AccompanyPostEntity accompanyPostEntity, AccompanyStatusEnum accompanyStatusEnum) {
         this.accompanyPostEntity = accompanyPostEntity;
         this.accompanyStatusEnum = accompanyStatusEnum;
-    }
-
-    public void updateStatus() {
-        if (accompanyStatusEnum == AccompanyStatusEnum.PROGRESSING) {
-            accompanyStatusEnum = AccompanyStatusEnum.CLOSED;
-        } else if (accompanyStatusEnum == AccompanyStatusEnum.CLOSED) {
-            accompanyStatusEnum = AccompanyStatusEnum.FINISHED;
-        } else {
-            throw new AlreadyFinishedAccompanyStatusException();
-        }
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/accompany_status/service/AccompanyStatusServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany_status/service/AccompanyStatusServiceImpl.java
@@ -1,6 +1,8 @@
 package connectripbe.connectrip_be.accompany_status.service;
 
 import connectripbe.connectrip_be.accompany_status.entity.AccompanyStatusEntity;
+import connectripbe.connectrip_be.accompany_status.entity.AccompanyStatusEnum;
+import connectripbe.connectrip_be.accompany_status.exception.AlreadyFinishedAccompanyStatusException;
 import connectripbe.connectrip_be.accompany_status.exception.NotFoundAccompanyStatusException;
 import connectripbe.connectrip_be.accompany_status.repository.AccompanyStatusJpaRepository;
 import connectripbe.connectrip_be.accompany_status.response.AccompanyStatusResponse;
@@ -49,7 +51,13 @@ public class AccompanyStatusServiceImpl implements AccompanyStatusService {
         AccompanyStatusEntity accompanyStatusEntity = accompanyStatusJpaRepository.findTopByAccompanyPostEntityOrderByCreatedAtDesc(accompanyPostEntity)
                 .orElseThrow(NotFoundAccompanyPostException::new);
 
-        accompanyStatusEntity.updateStatus();
+        if (accompanyStatusEntity.getAccompanyStatusEnum() == AccompanyStatusEnum.PROGRESSING) {
+            accompanyStatusJpaRepository.save(new AccompanyStatusEntity(accompanyPostEntity, AccompanyStatusEnum.CLOSED));
+        } else if (accompanyStatusEntity.getAccompanyStatusEnum() == AccompanyStatusEnum.CLOSED) {
+            accompanyStatusJpaRepository.save(new AccompanyStatusEntity(accompanyPostEntity, AccompanyStatusEnum.FINISHED));
+        } else {
+            throw new AlreadyFinishedAccompanyStatusException();
+        }
     }
 
     private void validateAccompanyPostOwnership(MemberEntity memberEntity, AccompanyPostEntity accompanyPostEntity) {


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 의도와 다르게 동행 게시글 상태를 컬럼을 쌓는 식으로 상태를 변경하는 것이 아닌 update를 통해 변경하는 문제 발생 -> 추적 불가
- 동행 상태 게시글 테이블이 accompany_status_entity로 저장되는 문제 발생


### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- update를 하지 않고, 계속해서 삽입해 변경 사항을 추적할 수 있도록 수정
- `@table` 어노테이션을 추가로 accompany_status로 테이블명 지정

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 