### PR TITLE
카카오 로그인 후 추가 정보 입력 API에서 닉네임이 중복 시 409와 다른 결과를 응답하도록 변경

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/member/service/MemberServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/member/service/MemberServiceImpl.java
@@ -57,8 +57,9 @@ public class MemberServiceImpl implements MemberService {
         MemberEntity memberEntity = memberJpaRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
 
+        // fixme-noah: 추후 글로벌 response가 정해지면 exception handler로 변경
         if (memberJpaRepository.existsByNickname(request.nickname())) {
-            throw new DuplicateMemberNicknameException();
+            return new GlobalResponse<>("DUPLICATED_NICKNAME", null);
         }
 
         memberEntity.firstUpdate(request.nickname(), request.birthDate(), request.gender());

--- a/src/main/java/connectripbe/connectrip_be/member/web/MemberController.java
+++ b/src/main/java/connectripbe/connectrip_be/member/web/MemberController.java
@@ -8,6 +8,7 @@ import connectripbe.connectrip_be.member.dto.FirstUpdateMemberRequest;
 import connectripbe.connectrip_be.member.dto.MemberHeaderInfoDto;
 import connectripbe.connectrip_be.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -32,8 +33,11 @@ public class MemberController {
         return memberService.getMemberHeaderInfo(email);
     }
 
+    // fixme-noah: 2024-08-21, 엉망 코드
     @PostMapping("/first")
-    public GlobalResponse<MemberHeaderInfoDto> firstUpdateMember(@LoginUser String email, @RequestBody FirstUpdateMemberRequest request) {
-        return memberService.getFirstUpdateMemberResponse(email, request);
+    public ResponseEntity<GlobalResponse<MemberHeaderInfoDto>> firstUpdateMember(@LoginUser String email, @RequestBody FirstUpdateMemberRequest request) {
+        GlobalResponse<MemberHeaderInfoDto> firstUpdateMemberResponse = memberService.getFirstUpdateMemberResponse(email, request);
+
+        return ResponseEntity.status(firstUpdateMemberResponse.message().equals("SUCCESS") ? 200 : 409).body(firstUpdateMemberResponse);
     }
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 카카오 로그인 후 추가 정보 입력 API에서 닉네임 중복에 대한 처리 없음

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 카카오 로그인 후 추가 정보 입력 API에서 닉네임이 중복 시 409와 다른 결과를 응답하도록 변경

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [X] API 테스트