### PR TITLE
hot-fix: 댓글 응답에 사용자 닉네임 및 프로필 이미지 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
@@ -19,6 +19,8 @@ public class AccompanyCommentResponse {
     private Long id;  // 댓글 아이디
     private Long memberId;  // 사용자 아이디
     private Long accompanyPostId;  // 동행 아이디
+    private String memberNickname;  // 사용자 닉네임
+    private String memberProfileImage;  // 사용자 프로필 이미지
     private String content;  // 내용
     private LocalDateTime createdAt;  // 생성 일자
     private LocalDateTime updatedAt;
@@ -30,6 +32,8 @@ public class AccompanyCommentResponse {
                 .id(comment.getId())
                 .memberId(comment.getMemberEntity().getId())
                 .accompanyPostId(comment.getAccompanyPostEntity().getId())
+                .memberNickname(comment.getMemberEntity().getNickname())
+                .memberProfileImage(comment.getMemberEntity().getProfileImagePath())
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())

--- a/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
@@ -54,4 +54,4 @@ public class AccompanyCommentResponse {
                 .format(UTC_FORMATTER);
     }
 }
-}
+

--- a/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
@@ -1,6 +1,8 @@
 package connectripbe.connectrip_be.comment.dto;
 
 import connectripbe.connectrip_be.comment.entity.AccompanyCommentEntity;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,9 +24,9 @@ public class AccompanyCommentResponse {
     private String memberNickname;  // 사용자 닉네임
     private String memberProfileImage;  // 사용자 프로필 이미지
     private String content;  // 내용
-    private LocalDateTime createdAt;  // 생성 일자
-    private LocalDateTime updatedAt;
-    private LocalDateTime deletedAt;  // 삭제 일자 (null 가능)
+    private String createdAt;  // 생성 일자
+    private String updatedAt;
+    private String deletedAt;  // 삭제 일자 (null 가능)
 
     // 엔티티를 DTO로 변환하는 메서드
     public static AccompanyCommentResponse fromEntity(AccompanyCommentEntity comment) {
@@ -35,9 +37,21 @@ public class AccompanyCommentResponse {
                 .memberNickname(comment.getMemberEntity().getNickname())
                 .memberProfileImage(comment.getMemberEntity().getProfileImagePath())
                 .content(comment.getContent())
-                .createdAt(comment.getCreatedAt())
-                .updatedAt(comment.getUpdatedAt())
-                .deletedAt(comment.getDeletedAt())
+                .createdAt(formatToUTC(comment.getCreatedAt()))
+                .updatedAt(formatToUTC(comment.getUpdatedAt()))
+                .deletedAt(formatToUTC(comment.getDeletedAt()))
                 .build();
     }
+    // UTC 형식으로 변환하는 메서드 추가
+    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    private static String formatToUTC(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        return dateTime.atZone(ZoneId.systemDefault())
+                .withZoneSameInstant(ZoneId.of("UTC"))
+                .format(UTC_FORMATTER);
+    }
+}
 }


### PR DESCRIPTION
### 제목
fix: 댓글 응답에 사용자 닉네임 및 프로필 이미지 추가

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 댓글 조회 시 사용자 정보(닉네임 및 프로필 이미지)가 응답에 포함되지 않는 문제

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- `AccompanyCommentResponse` DTO에 사용자 닉네임(`memberNickname`) 및 프로필 이미지(`memberProfileImage`) 필드 추가
- 댓글 응답 시 사용자 닉네임과 프로필 이미지 정보를 포함하도록 `fromEntity` 메서드 수정

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 