### PR TITLE
fix: 댓글 조회 시 URL 경로 수정 및 AccompanyCommentResponse 클래스 리팩토링

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
@@ -10,8 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
+
 
 @Getter
 @Setter
@@ -44,9 +43,11 @@ public class AccompanyCommentResponse {
                 .updatedAt(formatToUTC(comment.getUpdatedAt()))
                 .deletedAt(formatToUTC(comment.getDeletedAt()))
                 .build();
+    }
 
     // UTC 형식으로 변환하는 메서드 추가
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     private static String formatToUTC(LocalDateTime dateTime) {
         if (dateTime == null) {
@@ -57,4 +58,3 @@ public class AccompanyCommentResponse {
                 .format(UTC_FORMATTER);
     }
 }
-

--- a/src/main/java/connectripbe/connectrip_be/comment/web/AccompanyCommentController.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/web/AccompanyCommentController.java
@@ -26,8 +26,8 @@ public class AccompanyCommentController {
      * @param postId 댓글을 조회할 게시물의 ID
      * @return 댓글 목록을 담은 ResponseEntity<List<AccompanyCommentResponse>>
      */
-    @GetMapping
-    public ResponseEntity<List<AccompanyCommentResponse>> getCommentList(@RequestParam("postId") Long postId) {
+    @GetMapping("/{postId}")
+    public ResponseEntity<List<AccompanyCommentResponse>> getCommentList(@PathVariable Long postId) {
         List<AccompanyCommentResponse> comments = accompanyCommentService.getCommentsByPost(postId);
         return ResponseEntity.ok(comments);
     }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 댓글 조회 시 URL 경로가 잘못되어 요청이 실패하는 문제
- [ ] `AccompanyCommentResponse` 클래스 내 코드 정리 및 리팩토링 필요

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- `AccompanyCommentController`의 댓글 조회 경로를 `@RequestParam`에서 `@PathVariable`로 수정
- `AccompanyCommentResponse` 클래스에서 UTC 형식 변환 메서드의 코드 정리

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 