### PR TITLE
feat: 채팅방의 참여자 목록 조회 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/auth/config/SecurityConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/config/SecurityConfig.java
@@ -77,8 +77,8 @@ public class SecurityConfig {
                     antMatcher(POST,"/api/v1/comment"),
                     antMatcher(PATCH,"/api/v1/comment"),
                     antMatcher(DELETE,"/api/v1/comment"),
-                    antMatcher(GET,"/api/v1/comment")
-
+                    antMatcher(GET,"/api/v1/comment"),
+                    antMatcher(GET,"/api/v1/chatRoom")
             );
             return requestMatchers.toArray(RequestMatcher[]::new);
       }

--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomMemberResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomMemberResponse.java
@@ -1,0 +1,28 @@
+package connectripbe.connectrip_be.chat.dto;
+
+
+import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
+import lombok.Builder;
+
+
+@Builder
+public record ChatRoomMemberResponse(
+        Long chatRoomId,
+        Long memberId,
+        String memberEmail,
+        String memberNickname,
+        String memberProfileImage,
+        String memberChatRoomStatus
+) {
+
+    public static ChatRoomMemberResponse fromEntity(ChatRoomMemberEntity chatRoomMember){
+        return ChatRoomMemberResponse.builder()
+                .chatRoomId(chatRoomMember.getChatRoom().getId())
+                .memberId(chatRoomMember.getMember().getId())
+                .memberEmail(chatRoomMember.getMember().getEmail())
+                .memberNickname(chatRoomMember.getMember().getNickname())
+                .memberProfileImage(chatRoomMember.getMember().getProfileImagePath())
+                .memberChatRoomStatus(chatRoomMember.getStatus().toString())
+                .build();
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/type/ChatRoomMemberStatus.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/type/ChatRoomMemberStatus.java
@@ -9,5 +9,6 @@ public enum ChatRoomMemberStatus {
       ACTIVE("활성"),
       EXIT("나감");
 
-      private final String status;
+
+      private final String message;
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
@@ -11,4 +11,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMemberEn
 
       List<ChatRoomMemberEntity> findByMember_Email(String email);
 
+      List<ChatRoomMemberEntity> findByChatRoom_Id(Long chatRoomId);
+
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
@@ -1,10 +1,12 @@
 package connectripbe.connectrip_be.chat.service;
 
 import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
+import connectripbe.connectrip_be.chat.dto.ChatRoomMemberResponse;
 import java.util.List;
 
 public interface ChatRoomService {
 
       List<ChatRoomListResponse> getChatRoomList(String email);
 
+      List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
@@ -1,13 +1,16 @@
 package connectripbe.connectrip_be.chat.service.impl;
 
 import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
+import connectripbe.connectrip_be.chat.dto.ChatRoomMemberResponse;
 import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
 
+import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
 import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
 import connectripbe.connectrip_be.chat.service.ChatRoomService;
 
 
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +33,26 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
             return chatRoomMembers.stream()
                     .map(member -> ChatRoomListResponse.fromEntity(member.getChatRoom()))
+                    .toList();
+      }
+
+      /**
+       * 주어진 채팅방의 참여자 목록을 조회하여 반환하는 메서드.
+       * 주어진 채팅방의 ID를 기반으로 해당 채팅방의 모든 참여자를 조회
+       *
+       * @param chatRoomId 채팅방의 ID. 이 ID를 기반으로 해당 채팅방의 참여자를 조회
+       * @return 채팅방의 참여자 목록을 포함하는 `List<ChatRoomMemberResponse>` 채팅방에 참여한 사용자가 없을 경우 빈 리스트를 반환
+       */
+      @Override
+      public List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId) {
+
+            List<ChatRoomMemberEntity> chatRoomMembers = chatRoomMemberRepository.findByChatRoom_Id(
+                    chatRoomId);
+
+            return chatRoomMembers.stream()
+                    .filter(member -> !Objects.equals(member.getStatus(),
+                            ChatRoomMemberStatus.EXIT))
+                    .map(ChatRoomMemberResponse::fromEntity)
                     .toList();
       }
 

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,5 +22,13 @@ public class ChatRoomController {
       public ResponseEntity<List<ChatRoomListResponse>> getChatRoomList(@LoginUser String email) {
             return ResponseEntity.ok(chatRoomService.getChatRoomList(email));
       }
+
+
+      // 해당 채팅방 참여자 목록 조회
+      @GetMapping("/{chatRoomId}/members")
+      public ResponseEntity<?> getChatRoomMembers(@PathVariable Long chatRoomId) {
+            return ResponseEntity.ok(chatRoomService.getChatRoomMembers(chatRoomId));
+      }
+
 
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 채팅방에서 특정 채팅방의 참여자 목록을 조회할 수 있는 기능이 필요했습니다. 이를 통해 사용자는 채팅방에 어떤 멤버들이 있는지 확인할 수 있습니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- `ChatRoomService`에 채팅방 참여자 목록 조회 기능 추가
- `ChatRoomServiceImpl` 클래스에 `getChatRoomMembers` 메서드 추가, 해당 메서드는 특정 채팅방의 참여자 목록을 반환합니다.
- `ChatRoomMemberRepository`에 `findByChatRoom_Id` 메서드 추가, 이를 통해 특정 채팅방 ID로 참여자를 조회할 수 있습니다.
- `ChatRoomMemberResponse` 클래스 추가, 채팅방 참여자의 정보를 담는 DTO입니다.
- `ChatRoomController`에 `/api/v1/chatRoom/{chatRoomId}/members` 엔드포인트 추가, 이를 통해 특정 채팅방의 참여자 목록을 조회할 수 있습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
> 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트