### PR TITLE
동행 게시글 중 커스텀 URL 중복 확인 API 추가, 동행 게시글 생성 중 커스텀 URL 중복 확인 로직 추가, 응답 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
 
     // Accompany Post, 동행 게시글
     NOT_FOUND_ACCOMPANY_POST(HttpStatus.NOT_FOUND, "동행 게시글을 찾을 수 없습니다."),
+    DUPLICATED_CUSTOM_URL(HttpStatus.CONFLICT, "중복된 커스텀 URL 입니다."),
 
     //  Accompany Status, 동행 상태
     NOT_FOUND_ACCOMPANY_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "동행 상태를 찾을 수 없습니다."),

--- a/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostRequest.java
@@ -9,6 +9,7 @@ public record AccompanyPostRequest(
         String content,
         AccompanyArea accompanyArea,
         LocalDateTime startDate,
-        LocalDateTime endDate
+        LocalDateTime endDate,
+        String customURl
 ) {
 }

--- a/src/main/java/connectripbe/connectrip_be/post/dto/CheckDuplicatedCustomUrlDto.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/CheckDuplicatedCustomUrlDto.java
@@ -1,0 +1,4 @@
+package connectripbe.connectrip_be.post.dto;
+
+public record CheckDuplicatedCustomUrlDto(boolean isDuplicatedCustomUrl) {
+}

--- a/src/main/java/connectripbe/connectrip_be/post/dto/CreateAccompanyPostRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/CreateAccompanyPostRequest.java
@@ -10,6 +10,6 @@ public record CreateAccompanyPostRequest(
         AccompanyArea accompanyArea,
         LocalDateTime startDate,
         LocalDateTime endDate,
-        String customURl
+        String customUrl
 ) {
 }

--- a/src/main/java/connectripbe/connectrip_be/post/dto/CreateAccompanyPostRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/CreateAccompanyPostRequest.java
@@ -4,7 +4,7 @@ import connectripbe.connectrip_be.post.entity.enums.AccompanyArea;
 
 import java.time.LocalDateTime;
 
-public record AccompanyPostRequest(
+public record CreateAccompanyPostRequest(
         String title,
         String content,
         AccompanyArea accompanyArea,

--- a/src/main/java/connectripbe/connectrip_be/post/dto/UpdateAccompanyPostRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/UpdateAccompanyPostRequest.java
@@ -1,0 +1,16 @@
+package connectripbe.connectrip_be.post.dto;
+
+import connectripbe.connectrip_be.post.entity.enums.AccompanyArea;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record UpdateAccompanyPostRequest(
+        String title,
+        String content,
+        AccompanyArea accompanyArea,
+        LocalDateTime startDate,
+        LocalDateTime endDate
+) {
+}

--- a/src/main/java/connectripbe/connectrip_be/post/exception/DuplicatedCustomUrlException.java
+++ b/src/main/java/connectripbe/connectrip_be/post/exception/DuplicatedCustomUrlException.java
@@ -1,0 +1,11 @@
+package connectripbe.connectrip_be.post.exception;
+
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+
+public class DuplicatedCustomUrlException extends GlobalException {
+
+    public DuplicatedCustomUrlException() {
+        super(ErrorCode.DUPLICATED_CUSTOM_URL);
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/post/repository/AccompanyPostRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/post/repository/AccompanyPostRepository.java
@@ -19,4 +19,6 @@ public interface AccompanyPostRepository extends JpaRepository<AccompanyPostEnti
     List<AccompanyPostEntity> findAllByQuery(@Param("query") String query);
 
     List<AccompanyPostEntity> findAllByDeletedAtIsNullOrderByCreatedAtDesc();
+
+    boolean existsByCustomUrl(String customUrl);
 }

--- a/src/main/java/connectripbe/connectrip_be/post/service/AccompanyPostService.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/AccompanyPostService.java
@@ -22,4 +22,6 @@ public interface AccompanyPostService {
     List<AccompanyPostListResponse> accompanyPostList();
 
     List<AccompanyPostListResponse> searchByQuery(String query);
+
+    boolean checkDuplicatedCustomUrl(String customUrl);
 }

--- a/src/main/java/connectripbe/connectrip_be/post/service/AccompanyPostService.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/AccompanyPostService.java
@@ -1,19 +1,20 @@
 package connectripbe.connectrip_be.post.service;
 
 import connectripbe.connectrip_be.post.dto.AccompanyPostListResponse;
-import connectripbe.connectrip_be.post.dto.AccompanyPostRequest;
+import connectripbe.connectrip_be.post.dto.CreateAccompanyPostRequest;
 import connectripbe.connectrip_be.post.dto.AccompanyPostResponse;
+import connectripbe.connectrip_be.post.dto.UpdateAccompanyPostRequest;
 
 import java.util.List;
 
 
 public interface AccompanyPostService {
 
-    AccompanyPostResponse createAccompanyPost(String memberEmail, AccompanyPostRequest request);
+    AccompanyPostResponse createAccompanyPost(String memberEmail, CreateAccompanyPostRequest request);
 
     AccompanyPostResponse readAccompanyPost(long id);
 
-    AccompanyPostResponse updateAccompanyPost(String memberEmail, long id, AccompanyPostRequest request);
+    AccompanyPostResponse updateAccompanyPost(String memberEmail, long id, UpdateAccompanyPostRequest request);
 
     void deleteAccompanyPost(String memberEmail, long id);
 

--- a/src/main/java/connectripbe/connectrip_be/post/service/AccompanyPostService.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/AccompanyPostService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface AccompanyPostService {
 
-    AccompanyPostResponse createAccompanyPost(String memberEmail, CreateAccompanyPostRequest request);
+    void createAccompanyPost(String memberEmail, CreateAccompanyPostRequest request);
 
     AccompanyPostResponse readAccompanyPost(long id);
 

--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -43,7 +43,7 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
                 .content(request.content())
                 .accompanyArea(request.accompanyArea())
                 .urlQrPath("temp")
-                .customUrl("temp")
+                .customUrl(request.customURl())
                 .requestStatus("DEFAULT")
                 .build();
 

--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -5,10 +5,7 @@ import connectripbe.connectrip_be.accompany_status.entity.AccompanyStatusEnum;
 import connectripbe.connectrip_be.accompany_status.repository.AccompanyStatusJpaRepository;
 import connectripbe.connectrip_be.member.exception.MemberNotOwnerException;
 import connectripbe.connectrip_be.member.exception.NotFoundMemberException;
-import connectripbe.connectrip_be.post.dto.AccompanyPostListResponse;
-import connectripbe.connectrip_be.post.dto.CreateAccompanyPostRequest;
-import connectripbe.connectrip_be.post.dto.AccompanyPostResponse;
-import connectripbe.connectrip_be.post.dto.UpdateAccompanyPostRequest;
+import connectripbe.connectrip_be.post.dto.*;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
 import connectripbe.connectrip_be.post.exception.NotFoundAccompanyPostException;
 import connectripbe.connectrip_be.post.repository.AccompanyPostRepository;
@@ -44,7 +41,7 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
                 .content(request.content())
                 .accompanyArea(request.accompanyArea())
                 .urlQrPath("temp")
-                .customUrl(request.customURl())
+                .customUrl(request.customUrl())
                 .requestStatus("DEFAULT")
                 .build();
 
@@ -106,6 +103,12 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     public List<AccompanyPostListResponse> searchByQuery(String query) {
         return accompanyPostRepository.findAllByQuery(query).stream()
                 .map(AccompanyPostListResponse::fromEntity).toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean checkDuplicatedCustomUrl(String customUrl) {
+        return accompanyPostRepository.existsByCustomUrl(customUrl);
     }
 
     private MemberEntity findMemberEntity(String email) {

--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -7,6 +7,7 @@ import connectripbe.connectrip_be.member.exception.MemberNotOwnerException;
 import connectripbe.connectrip_be.member.exception.NotFoundMemberException;
 import connectripbe.connectrip_be.post.dto.*;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import connectripbe.connectrip_be.post.exception.DuplicatedCustomUrlException;
 import connectripbe.connectrip_be.post.exception.NotFoundAccompanyPostException;
 import connectripbe.connectrip_be.post.repository.AccompanyPostRepository;
 import connectripbe.connectrip_be.post.service.AccompanyPostService;
@@ -29,8 +30,12 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     private final AccompanyStatusJpaRepository accompanyStatusJpaRepository;
 
     @Override
-    public AccompanyPostResponse createAccompanyPost(String memberEmail, CreateAccompanyPostRequest request) {
+    public void createAccompanyPost(String memberEmail, CreateAccompanyPostRequest request) {
         MemberEntity memberEntity = findMemberEntity(memberEmail);
+
+        if (checkDuplicatedCustomUrl(request.customUrl())) {
+            throw new DuplicatedCustomUrlException();
+        }
 
         AccompanyPostEntity post = AccompanyPostEntity.builder()
                 .memberEntity(memberEntity)
@@ -47,9 +52,6 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
 
         accompanyPostRepository.save(post);
         accompanyStatusJpaRepository.save(new AccompanyStatusEntity(post, AccompanyStatusEnum.PROGRESSING));
-
-        // 생성된 데이터를 응답으로 반환
-        return AccompanyPostResponse.fromEntity(post);
     }
 
     @Override

--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -6,8 +6,9 @@ import connectripbe.connectrip_be.accompany_status.repository.AccompanyStatusJpa
 import connectripbe.connectrip_be.member.exception.MemberNotOwnerException;
 import connectripbe.connectrip_be.member.exception.NotFoundMemberException;
 import connectripbe.connectrip_be.post.dto.AccompanyPostListResponse;
-import connectripbe.connectrip_be.post.dto.AccompanyPostRequest;
+import connectripbe.connectrip_be.post.dto.CreateAccompanyPostRequest;
 import connectripbe.connectrip_be.post.dto.AccompanyPostResponse;
+import connectripbe.connectrip_be.post.dto.UpdateAccompanyPostRequest;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
 import connectripbe.connectrip_be.post.exception.NotFoundAccompanyPostException;
 import connectripbe.connectrip_be.post.repository.AccompanyPostRepository;
@@ -31,7 +32,7 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     private final AccompanyStatusJpaRepository accompanyStatusJpaRepository;
 
     @Override
-    public AccompanyPostResponse createAccompanyPost(String memberEmail, AccompanyPostRequest request) {
+    public AccompanyPostResponse createAccompanyPost(String memberEmail, CreateAccompanyPostRequest request) {
         MemberEntity memberEntity = findMemberEntity(memberEmail);
 
         AccompanyPostEntity post = AccompanyPostEntity.builder()
@@ -63,7 +64,7 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     }
 
     @Override
-    public AccompanyPostResponse updateAccompanyPost(String memberEmail, long id, AccompanyPostRequest request) {
+    public AccompanyPostResponse updateAccompanyPost(String memberEmail, long id, UpdateAccompanyPostRequest request) {
         MemberEntity memberEntity = findMemberEntity(memberEmail);
 
         AccompanyPostEntity accompanyPostEntity = findAccompanyPostEntity(id);

--- a/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
+++ b/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
@@ -3,6 +3,7 @@ package connectripbe.connectrip_be.post.web;
 import connectripbe.connectrip_be.auth.config.LoginUser;
 import connectripbe.connectrip_be.global.dto.GlobalResponse;
 import connectripbe.connectrip_be.post.dto.*;
+import connectripbe.connectrip_be.post.exception.DuplicatedCustomUrlException;
 import connectripbe.connectrip_be.post.service.AccompanyPostService;
 
 import java.util.List;
@@ -19,10 +20,10 @@ public class AccompanyPostController {
     private final AccompanyPostService accompanyPostService;
 
     @PostMapping
-    public ResponseEntity<AccompanyPostResponse> createAccompanyPost(@LoginUser String memberEmail,
-                                                                     @RequestBody CreateAccompanyPostRequest request) {
-        AccompanyPostResponse response = accompanyPostService.createAccompanyPost(memberEmail, request);
-        return ResponseEntity.ok(response);  // 데이터가 포함된 응답 반환
+    public ResponseEntity<GlobalResponse<?>> createAccompanyPost(@LoginUser String memberEmail,
+                                                                 @RequestBody CreateAccompanyPostRequest request) {
+        accompanyPostService.createAccompanyPost(memberEmail, request);
+        return ResponseEntity.ok(new GlobalResponse<>("SUCCESS", null));
     }
 
     // 게시글 조회
@@ -66,5 +67,10 @@ public class AccompanyPostController {
         boolean result = accompanyPostService.checkDuplicatedCustomUrl(customUrl);
 
         return ResponseEntity.status(result ? 409 : 200).body(new GlobalResponse<>(result ? "DUPLICATED_CUSTOM_URL" : "SUCCESS", new CheckDuplicatedCustomUrlDto(result)));
+    }
+
+    @ExceptionHandler(DuplicatedCustomUrlException.class)
+    public ResponseEntity<GlobalResponse<CheckDuplicatedCustomUrlDto>> handleException(Exception e) {
+        return ResponseEntity.status(409).body(new GlobalResponse<>("DUPLICATED_CUSTOM_URL", null));
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
+++ b/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
@@ -1,10 +1,8 @@
 package connectripbe.connectrip_be.post.web;
 
 import connectripbe.connectrip_be.auth.config.LoginUser;
-import connectripbe.connectrip_be.post.dto.AccompanyPostListResponse;
-import connectripbe.connectrip_be.post.dto.CreateAccompanyPostRequest;
-import connectripbe.connectrip_be.post.dto.AccompanyPostResponse;
-import connectripbe.connectrip_be.post.dto.UpdateAccompanyPostRequest;
+import connectripbe.connectrip_be.global.dto.GlobalResponse;
+import connectripbe.connectrip_be.post.dto.*;
 import connectripbe.connectrip_be.post.service.AccompanyPostService;
 
 import java.util.List;
@@ -60,5 +58,13 @@ public class AccompanyPostController {
     @GetMapping("/search")
     public ResponseEntity<List<AccompanyPostListResponse>> searchByQuery(@RequestParam String query) {
         return ResponseEntity.ok(accompanyPostService.searchByQuery(query));
+    }
+
+    // fixme-noah: 추후 다르 중복 확인 메서드 모두 이름 수정, 혼동 있음
+    @GetMapping("/check-custom-url")
+    public ResponseEntity<GlobalResponse<CheckDuplicatedCustomUrlDto>> checkDuplicatedCustomUrl(@RequestParam String customUrl) {
+        boolean result = accompanyPostService.checkDuplicatedCustomUrl(customUrl);
+
+        return ResponseEntity.status(result ? 409 : 200).body(new GlobalResponse<>(result ? "DUPLICATED_CUSTOM_URL" : "SUCCESS", new CheckDuplicatedCustomUrlDto(result)));
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
+++ b/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
@@ -2,8 +2,9 @@ package connectripbe.connectrip_be.post.web;
 
 import connectripbe.connectrip_be.auth.config.LoginUser;
 import connectripbe.connectrip_be.post.dto.AccompanyPostListResponse;
-import connectripbe.connectrip_be.post.dto.AccompanyPostRequest;
+import connectripbe.connectrip_be.post.dto.CreateAccompanyPostRequest;
 import connectripbe.connectrip_be.post.dto.AccompanyPostResponse;
+import connectripbe.connectrip_be.post.dto.UpdateAccompanyPostRequest;
 import connectripbe.connectrip_be.post.service.AccompanyPostService;
 
 import java.util.List;
@@ -21,7 +22,7 @@ public class AccompanyPostController {
 
     @PostMapping
     public ResponseEntity<AccompanyPostResponse> createAccompanyPost(@LoginUser String memberEmail,
-                                                                     @RequestBody AccompanyPostRequest request) {
+                                                                     @RequestBody CreateAccompanyPostRequest request) {
         AccompanyPostResponse response = accompanyPostService.createAccompanyPost(memberEmail, request);
         return ResponseEntity.ok(response);  // 데이터가 포함된 응답 반환
     }
@@ -37,7 +38,7 @@ public class AccompanyPostController {
     public ResponseEntity<AccompanyPostResponse> updateAccompanyPost(
             @LoginUser String memberEmail,
             @PathVariable Long id,
-            @RequestBody AccompanyPostRequest request) {
+            @RequestBody UpdateAccompanyPostRequest request) {
         AccompanyPostResponse response = accompanyPostService.updateAccompanyPost(memberEmail, id, request);
         return ResponseEntity.ok(response);  // 수정된 데이터 반환
     }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 동행 게시글 중 커스텀 URL 관련 API가 없음

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 동행 게시글 중 커스텀 URL 중복 확인 API 추가
- 동행 게시글 생성 중 커스텀 URL 중복 확인 로직 추가
- 동행 게시글 생성에 대한 응답 수정

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [X] API 테스트