### PR TITLE
feat: Pending List 기능 추가 및 AccompanyArea 사용 방식 변경

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     PASSWORD_EMPTY(HttpStatus.BAD_REQUEST, "비밀번호를 입력해주세요."),
     OVER_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "모임 최대 인원수를 초과했습니다."),
     PENDING_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 신청을 찾을 수 없습니다."),
+    PENDING_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 신청한 상태입니다."),
 
     // Member, 사용자
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
     PASSWORD_EMPTY(HttpStatus.BAD_REQUEST, "비밀번호를 입력해주세요."),
     OVER_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "모임 최대 인원수를 초과했습니다."),
+    PENDING_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 신청을 찾을 수 없습니다."),
 
     // Member, 사용자
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingListResponse.java
@@ -1,0 +1,11 @@
+package connectripbe.connectrip_be.pending_list.dto;
+
+import connectripbe.connectrip_be.pending_list.entity.type.PendingStatus;
+import lombok.Builder;
+
+@Builder
+public record PendingListResponse(
+        PendingStatus status
+) {
+
+}

--- a/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingRequest.java
@@ -1,0 +1,9 @@
+package connectripbe.connectrip_be.pending_list.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PendingRequest(
+) {
+
+}

--- a/src/main/java/connectripbe/connectrip_be/pending_list/entity/PendingListEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/entity/PendingListEntity.java
@@ -1,0 +1,60 @@
+package connectripbe.connectrip_be.pending_list.entity;
+
+import connectripbe.connectrip_be.global.entity.BaseEntity;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.pending_list.entity.type.PendingStatus;
+import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "pending_list")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingListEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "accompany_post_id")
+    private AccompanyPostEntity accompanyPost;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PendingStatus status;
+
+
+    public void addPendingList(MemberEntity member, AccompanyPostEntity accompanyPost) {
+        this.member = member;
+        this.accompanyPost = accompanyPost;
+        this.status = PendingStatus.PENDING;
+    }
+
+    public void acceptStatus() {
+        this.status = PendingStatus.ACCEPT;
+    }
+
+    public void rejectStatus() {
+        this.status = PendingStatus.REJECT;
+    }
+
+}

--- a/src/main/java/connectripbe/connectrip_be/pending_list/entity/type/PendingStatus.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/entity/type/PendingStatus.java
@@ -1,0 +1,15 @@
+package connectripbe.connectrip_be.pending_list.entity.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PendingStatus {
+
+    PENDING("대기중"),
+    ACCEPT("수락"),
+    REJECT("거절");
+
+    private final String message;
+}

--- a/src/main/java/connectripbe/connectrip_be/pending_list/repository/PendingListRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/repository/PendingListRepository.java
@@ -1,0 +1,17 @@
+package connectripbe.connectrip_be.pending_list.repository;
+
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.pending_list.entity.PendingListEntity;
+import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PendingListRepository extends JpaRepository<PendingListEntity, Long> {
+
+    Optional<PendingListEntity> findByAccompanyPostAndMember(AccompanyPostEntity accompanyPost,
+            MemberEntity member);
+
+    boolean existsByMemberAndAccompanyPost(MemberEntity member, AccompanyPostEntity accompanyPost);
+}

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
@@ -1,0 +1,17 @@
+package connectripbe.connectrip_be.pending_list.service;
+
+
+import connectripbe.connectrip_be.pending_list.dto.PendingListResponse;
+
+public interface PendingListService {
+
+    //TODO 게시물 작성자가 해당 게시물에 신청한 사용자들의 리스트를 조회하는 api
+
+    // 현재 로그인 한 사용자가 게시물에 신청된 상태 확인 api
+     PendingListResponse getMyPendingStatus(Long accompanyPostId,String email);
+
+    // 사용자가 해당 게시물에 신청하는 api
+    PendingListResponse accompanyPending(Long accompanyPostId,String email);
+
+
+}

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
@@ -1,0 +1,112 @@
+package connectripbe.connectrip_be.pending_list.service.impl;
+
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
+import connectripbe.connectrip_be.pending_list.dto.PendingListResponse;
+import connectripbe.connectrip_be.pending_list.entity.PendingListEntity;
+import connectripbe.connectrip_be.pending_list.entity.type.PendingStatus;
+import connectripbe.connectrip_be.pending_list.repository.PendingListRepository;
+import connectripbe.connectrip_be.pending_list.service.PendingListService;
+import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import connectripbe.connectrip_be.post.repository.AccompanyPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PendingListServiceImpl implements PendingListService {
+
+    // 의존성 주입된 레포지토리들
+    private final PendingListRepository pendingListRepository;
+    private final MemberJpaRepository memberJpaRepository;
+    private final AccompanyPostRepository accompanyPostRepository;
+
+    /**
+     * 현재 로그인한 사용자가 특정 동행 게시물에 대해 신청한 상태를 확인
+     *
+     * @param accompanyPostId 조회할 게시물의 ID
+     * @param email 현재 로그인한 사용자의 이메일
+     * @return PendingListResponse 사용자의 신청 상태를 반환하는 객체
+     * @throws GlobalException 사용자의 신청 상태를 찾을 수 없는 경우 예외 발생
+     */
+    @Override
+    public PendingListResponse getMyPendingStatus(Long accompanyPostId, String email) {
+        // 게시물 ID로 AccompanyPostEntity 조회
+        AccompanyPostEntity accompanyPost = getAccompanyPost(accompanyPostId);
+        // 이메일로 MemberEntity 조회
+        MemberEntity member = getMember(email);
+
+        // 게시물과 회원 정보를 바탕으로 PendingListEntity 조회
+        PendingListEntity pendingStatus = pendingListRepository.findByAccompanyPostAndMember(
+                        accompanyPost, member)
+                .orElseThrow(() -> new GlobalException(ErrorCode.PENDING_NOT_FOUND));
+
+        // 조회된 신청 상태를 반환
+        return PendingListResponse.builder()
+                .status(pendingStatus.getStatus())
+                .build();
+    }
+
+
+    /**
+     * 현재 로그인한 사용자가 특정 동행 게시물에 대해 새로운 동행 신청을 생성.
+     *
+     * @param accompanyPostId 신청할 게시물의 ID
+     * @param email 현재 로그인한 사용자의 이메일
+     * @return PendingListResponse 생성된 신청 상태를 반환하는 객체
+     * @throws GlobalException 사용자가 존재하지 않거나 게시물을 찾을 수 없는 경우 예외 발생
+     */
+    @Override
+    public PendingListResponse accompanyPending(Long accompanyPostId, String email) {
+        // 이메일로 MemberEntity 조회
+        MemberEntity member = getMember(email);
+        // 게시물 ID로 AccompanyPostEntity 조회
+        AccompanyPostEntity accompanyPost = getAccompanyPost(accompanyPostId);
+
+        // 이미 신청한 사용자인지 확인
+        if (pendingListRepository.existsByMemberAndAccompanyPost(member, accompanyPost)) {
+            throw new GlobalException(ErrorCode.PENDING_ALREADY_EXISTS);
+        }
+
+        // 새로운 PendingListEntity 생성
+        PendingListEntity pendingListEntity = PendingListEntity.builder()
+                .member(member)
+                .accompanyPost(accompanyPost)
+                .status(PendingStatus.PENDING)
+                .build();
+
+        // 생성된 엔티티를 저장
+        PendingListEntity saved = pendingListRepository.save(pendingListEntity);
+
+        // 저장된 신청 상태를 반환
+        return PendingListResponse.builder()
+                .status(saved.getStatus())
+                .build();
+    }
+
+    /**
+     * 이메일을 통해 MemberEntity 를 조회합니다.
+     *
+     * @param email 조회할 사용자의 이메일
+     * @return MemberEntity 이메일에 해당하는 사용자 엔티티
+     * @throws GlobalException 사용자를 찾을 수 없는 경우 예외 발생
+     */
+    private MemberEntity getMember(String email) {
+        return memberJpaRepository.findByEmail(email)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * 게시물 ID를 통해 AccompanyPostEntity 를 조회.
+     *
+     * @param accompanyPostId 조회할 게시물의 ID
+     * @return AccompanyPostEntity 게시물 엔티티
+     * @throws GlobalException 게시물을 찾을 수 없는 경우 예외 발생
+     */
+    private AccompanyPostEntity getAccompanyPost(Long accompanyPostId) {
+        return accompanyPostRepository.findById(accompanyPostId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
@@ -1,0 +1,34 @@
+package connectripbe.connectrip_be.pending_list.web;
+
+import connectripbe.connectrip_be.auth.config.LoginUser;
+import connectripbe.connectrip_be.pending_list.dto.PendingListResponse;
+import connectripbe.connectrip_be.pending_list.service.PendingListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/accompany/posts/{id}/pending")
+@RequiredArgsConstructor
+public class PendingListController {
+
+    private final PendingListService pendingListService;
+
+    // 동행 신청 상태 조회
+    @GetMapping
+    public ResponseEntity<PendingListResponse> getMyPendingStatus(@PathVariable Long id,
+            @LoginUser String email) {
+        return ResponseEntity.ok(pendingListService.getMyPendingStatus(id, email));
+    }
+
+    // 동행 신청
+    @PostMapping
+    public ResponseEntity<PendingListResponse> accompanyPending(@PathVariable Long id,
+            @LoginUser String email) {
+        return ResponseEntity.ok(pendingListService.accompanyPending(id, email));
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostListResponse.java
@@ -29,7 +29,7 @@ public record AccompanyPostListResponse(
                     .title(truncate(accompanyPost.getTitle(), 21))
                     .startDate(formatToUTC(accompanyPost.getStartDate()))
                     .endDate(formatToUTC(accompanyPost.getEndDate()))
-                    .accompanyArea(accompanyPost.getAccompanyArea().toString())
+                    .accompanyArea(accompanyPost.getAccompanyArea())
                     .content(truncate(accompanyPost.getContent(), 36))
                     .createdAt(formatToUTC(accompanyPost.getCreatedAt()))
                     .profileImagePath(accompanyPost.getMemberEntity().getProfileImagePath())

--- a/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostRequest.java
@@ -1,13 +1,12 @@
 package connectripbe.connectrip_be.post.dto;
 
-import connectripbe.connectrip_be.post.entity.enums.AccompanyArea;
 
 import java.time.LocalDateTime;
 
 public record AccompanyPostRequest(
         String title,
         String content,
-        AccompanyArea accompanyArea,
+        String accompanyArea,
         LocalDateTime startDate,
         LocalDateTime endDate
 ) {

--- a/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostResponse.java
@@ -34,7 +34,7 @@ public record AccompanyPostResponse(
                 .title(accompanyPost.getTitle())
                 .startDate(formatToUTC(accompanyPost.getStartDate()))
                 .endDate(formatToUTC(accompanyPost.getEndDate()))
-                .accompanyArea(accompanyPost.getAccompanyArea().getDisplayName())
+                .accompanyArea(accompanyPost.getAccompanyArea())
                 .customUrl(accompanyPost.getCustomUrl())
                 .urlQrPath(accompanyPost.getUrlQrPath())
                 .content(accompanyPost.getContent())

--- a/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
@@ -2,7 +2,6 @@ package connectripbe.connectrip_be.post.entity;
 
 import connectripbe.connectrip_be.global.entity.BaseEntity;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
-import connectripbe.connectrip_be.post.entity.enums.AccompanyArea;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,9 +31,7 @@ public class AccompanyPostEntity extends BaseEntity {
 
     private LocalDateTime endDate;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private AccompanyArea accompanyArea;
+    private String accompanyArea;
 
     // fixme-noah: customUrl 임시 보류
     private String customUrl;
@@ -50,7 +47,7 @@ public class AccompanyPostEntity extends BaseEntity {
     @Builder.Default
     private String requestStatus = "DEFAULT";
 
-    public AccompanyPostEntity(MemberEntity memberEntity, String title, LocalDateTime startDate, LocalDateTime endDate, AccompanyArea accompanyArea, String customUrl, String urlQrPath, String content) {
+    public AccompanyPostEntity(MemberEntity memberEntity, String title, LocalDateTime startDate, LocalDateTime endDate, String accompanyArea, String customUrl, String urlQrPath, String content) {
         this.memberEntity = memberEntity;
         this.title = title;
         this.startDate = startDate;
@@ -61,7 +58,7 @@ public class AccompanyPostEntity extends BaseEntity {
         this.content = content;
     }
 
-    public void updateAccompanyPost(String title, LocalDateTime startDate, LocalDateTime endDate, AccompanyArea accompanyArea, String content) {
+    public void updateAccompanyPost(String title, LocalDateTime startDate, LocalDateTime endDate, String accompanyArea, String content) {
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/connectripbe/connectrip_be/post/entity/enums/AccompanyArea.java
+++ b/src/main/java/connectripbe/connectrip_be/post/entity/enums/AccompanyArea.java
@@ -1,5 +1,10 @@
 package connectripbe.connectrip_be.post.entity.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum AccompanyArea {
     SEOUL("서울"),
     BUSAN("부산"),
@@ -21,20 +26,4 @@ public enum AccompanyArea {
 
     private final String displayName;
 
-    AccompanyArea(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public static AccompanyArea fromDisplayName(String displayName) {
-        for (AccompanyArea area : AccompanyArea.values()) {
-            if (area.getDisplayName().equals(displayName)) {
-                return area;
-            }
-        }
-        throw new IllegalArgumentException("Unknown display name: " + displayName);
-    }
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 동행 게시물에 대한 신청 기능을 추가하여 사용자가 특정 게시물에 신청하고, 
- 그 상태를 관리할 수 있는 시스템을 구축하기 위함.

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- **Pending List 기능 추가**:
  - `PendingListEntity` 및 관련 `PendingStatus` enum을 추가하여 사용자가 동행 게시물에 신청할 수 있는 기능을 구현.
  - `PendingListRepository`, `PendingListService`, `PendingListServiceImpl` 추가 및 구현. 사용자의 신청 상태를 확인하고 신청을 관리할 수 있는 메서드 구현.
  - `PendingListController`를 통해 동행 게시물 신청 API 및 신청 상태 조회 API 구현.

- **AccompanyArea 사용 변경**:
  - `AccompanyArea` enum의 `displayName` 필드를 제거하고, 동행 지역을 단순 문자열로 처리하도록 수정.
  - 관련된 모든 DTO 및 엔티티에서 `AccompanyArea` 사용 방식을 변경, enum 대신 문자열을 사용.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
> 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 작성
- [x] API 테스트 진행