### PR TITLE
fix: ChatRoomListResponse 멤버 수 추가 및 CreateAccompanyPostRequest 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
@@ -15,7 +15,8 @@ public record ChatRoomListResponse(
         String startDate,
         String endDate,
         String lastChatMessage,
-        String lastChatMessageTime
+        String lastChatMessageTime,
+        int memberNumber
         ) {
 
 
@@ -29,11 +30,12 @@ public record ChatRoomListResponse(
                     .chatRoomId(chatRoom.getId())
                     .accompanyPostId(chatRoom.getAccompanyPost().getId())
                     .accompanyPostTitle(chatRoom.getAccompanyPost().getTitle())
-                    .accompanyArea(chatRoom.getAccompanyPost().getAccompanyArea().toString())
+                    .accompanyArea(chatRoom.getAccompanyPost().getAccompanyArea())
                     .startDate(formatToUTC(chatRoom.getAccompanyPost().getStartDate()))
                     .endDate(formatToUTC(chatRoom.getAccompanyPost().getEndDate()))
                     .lastChatMessage(chatRoom.getLastChatMessage())
                     .lastChatMessageTime(formatToUTC(lastChatTime))
+                    .memberNumber(chatRoom.getChatRoomMembers().size())
                     .build();
       }
 

--- a/src/main/java/connectripbe/connectrip_be/post/dto/CreateAccompanyPostRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/CreateAccompanyPostRequest.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 public record CreateAccompanyPostRequest(
         String title,
         String content,
-        AccompanyArea accompanyArea,
+        String accompanyArea,
         LocalDateTime startDate,
         LocalDateTime endDate,
         String customUrl


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- ChatRoomListResponse에 채팅방 멤버 수를 추가하여 각 채팅방의 참여 인원을 확인할 수 있게 하고, CreateAccompanyPostRequest에서 AccompanyArea를 문자열로 처리하는 방식으로 변경하여 일관성을 유지하고자 합니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- **ChatRoomListResponse 변경**:
  - `ChatRoomListResponse`에 `memberNumber` 필드를 추가하여 채팅방의 참여자 수를 나타내도록 수정.
  - `ChatRoomEntity`에서 `getChatRoomMembers().size()`를 통해 멤버 수를 계산하여 해당 필드에 반영.

- **CreateAccompanyPostRequest 수정**:
  - `CreateAccompanyPostRequest`에서 `AccompanyArea` 필드를 문자열(`String`)로 변경하여 요청 데이터를 간소화하고 일관성 있는 데이터 처리를 도모.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
> 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 작성
- [ ] API 테스트 진행