### PR TITLE
Fix - global exception 리턴값 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/GlobalExceptionHandler.java
@@ -3,8 +3,10 @@ package connectripbe.connectrip_be.global.exception;
 
 import static connectripbe.connectrip_be.global.exception.type.ErrorCode.INTERNAL_SERVER_ERROR;
 
+import com.amazonaws.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -12,18 +14,22 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-      @ExceptionHandler(GlobalException.class)
-      public ErrorResponse handleCustomException(GlobalException e){
-            log.error("{} is occurred.", e.getErrorCode());
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(GlobalException e) {
+        log.error("{} is occurred.", e.getErrorCode());
 
-        return new ErrorResponse(e.getErrorCode(),
-            e.getErrorCode().getHttpStatus(), e.getErrorCode().getDescription());
-      }
-      @ExceptionHandler(Exception.class)
-      public ErrorResponse exceptionHandler(Exception e) {
-            log.error("Exception is occurred", e);
-            return new ErrorResponse(INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR,
-                    INTERNAL_SERVER_ERROR.getDescription());
-      }
+        return new ResponseEntity<>(
+                new ErrorResponse(e.getErrorCode(), e.getErrorCode().getHttpStatus(),
+                        e.getErrorCode().getDescription()),
+                e.getErrorCode().getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ErrorResponse exceptionHandler(Exception e) {
+        log.error("Exception is occurred", e);
+        return new ErrorResponse(INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR,
+                INTERNAL_SERVER_ERROR.getDescription());
+    }
 
 }


### PR DESCRIPTION
- GlobalExceptionHandler 클래스에서 예외 처리 메서드가 ResponseEntity를 반환하도록 수정했습니다.
- 기존에 ErrorResponse 객체를 반환하던 것을 ResponseEntity로 래핑하여 HTTP 상태 코드를 포함하게 했습니다.

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- GlobalExceptionHandler 클래스에서 예외 처리 메서드가 ResponseEntity를 반환하도록 수정했습니다.
- 기존에 ErrorResponse 객체를 반환하던 것을 ResponseEntity로 래핑하여 HTTP 상태 코드를 포함하게 했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 