### PR TITLE
fix: checkDuplicatedCustomUrl 메서드 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
+++ b/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
@@ -66,9 +66,13 @@ public class AccompanyPostController {
     public ResponseEntity<GlobalResponse<CheckDuplicatedCustomUrlDto>> checkDuplicatedCustomUrl(@RequestParam String customUrl) {
         boolean result = accompanyPostService.checkDuplicatedCustomUrl(customUrl);
 
-        return ResponseEntity.status(result ? 409 : 200).body(new GlobalResponse<>(result ? "DUPLICATED_CUSTOM_URL" : "SUCCESS", new CheckDuplicatedCustomUrlDto(result)));
+        return ResponseEntity.ok(
+                new GlobalResponse<>(
+                        result ? "DUPLICATED_CUSTOM_URL" : "SUCCESS",
+                        new CheckDuplicatedCustomUrlDto(result)
+                )
+        );
     }
-
     @ExceptionHandler(DuplicatedCustomUrlException.class)
     public ResponseEntity<GlobalResponse<CheckDuplicatedCustomUrlDto>> handleException(Exception e) {
         return ResponseEntity.status(409).body(new GlobalResponse<>("DUPLICATED_CUSTOM_URL", null));


### PR DESCRIPTION
- 상태 코드 반환을 409에서  200으로 변경하여 일관성 향상.

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 닉네임 중복 시 409로 반환. 중복과 괸련된 기능들은 200으로 통일하기. 

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 상태 코드 반환을 409에서  200으로 변경하여 일관성 향상.


### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 