### PR TITLE
fix: 본인이 작성한 글 신청시 오류 처리 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     OVER_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "모임 최대 인원수를 초과했습니다."),
     PENDING_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 신청을 찾을 수 없습니다."),
     PENDING_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 신청한 상태입니다."),
+    WRITE_YOURSELF(HttpStatus.BAD_REQUEST, "본인이 작성한 글은 신청할 수 없습니다."),
 
     // Member, 사용자
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingListResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record PendingListResponse(
-        PendingStatus status
+        String status
 ) {
 
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 사용자가 본인이 작성한 게시물에 신청을 시도할 때 발생하는 오류를 방지하기 위해 추가적인 예외 처리를 구현하여, 불필요한 오류 발생을 차단하고 사용자 경험을 개선하고자 합니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 -->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- **ErrorCode 추가**:
  - `WRITE_YOURSELF` 오류 코드를 추가하여, 사용자가 본인의 게시물에 신청하려는 시도를 할 경우 명확한 예외 처리를 가능하게 함.

- **PendingListResponse 수정**:
  - 상태 필드를 `PendingStatus`에서 `String`으로 변경하여 상태를 문자열로 쉽게 처리하고, 특정 예외 상황에 맞는 상태값(`DEFAULT`, `NONE`)을 반환할 수 있도록 수정.

- **PendingListServiceImpl 수정**:
  - `getMyPendingStatus` 메서드: 본인이 작성한 게시물에 대해 신청 상태를 조회하려는 경우 `WRITE_YOURSELF` 예외를 발생시키고, 이 예외에 대한 추가적인 상태값 처리를 구현.
  - `accompanyPending` 메서드: 본인이 작성한 게시물에 신청을 시도할 때 `WRITE_YOURSELF` 예외를 발생시켜 신청을 방지하고, 예외 발생 시 적절한 상태를 반환하도록 수정.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
> 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드 작성
- [ ] API 테스트 진행