### PR TITLE
chore: apply automated linting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.8'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'com.diffplug.spotless' version '6.25.0'
 }
 
 group = 'connectrip-be'
@@ -59,6 +60,31 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+spotless {
+    java {
+        googleJavaFormat().aosp()
+        importOrder('java', 'javax', 'jakarta', 'org', 'com')
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
+tasks.register('updateGitHooks', Copy) {
+    from './scripts/pre-commit'
+    into './.git/hooks'
+}
+
+tasks.register('makeGitHooksExecutable', Exec) {
+    commandLine 'chmod', '+x', './.git/hooks/pre-commit'
+    dependsOn updateGitHooks
+}
+
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.named('compileJava') {
+    dependsOn 'makeGitHooksExecutable'
+    dependsOn 'spotlessCheck'
 }

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# From https://github.com/diffplug/spotless/issues/178
+
+echo '[git hook] executing gradle spotlessCheck before commit'
+git stash -q --keep-index
+sh ./gradlew spotlessCheck --daemon
+
+RESULT=$?
+git stash pop -q
+
+exit $RESULT


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
- 프로젝트의 커밋 및 빌드 시 spotless 툴을 활용해 협업 과정에서 코드 품질이 균일하게 유지되도록 합니다

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
- 미리 정의된 규칙에 알맞게 코드가 formatting되지 않으면 다음의 행위가 불가합니다:
  - 변경 사항을 commit 할 수 없음
  - compile 되지 않음

- 포맷팅 규칙은 다음을 참고하여 `build.gradle`내 `spotless`에 정의합니다.
  - https://github.com/diffplug/spotless/blob/gradle/6.25.0/plugin-gradle/README.md

- 다음 두 command를 사용할 수 있습니다
  - check: `./gradlew spotlessCheck`
  - apply (정의된 규칙에 맞게 formatting 진행): `./gradlew spotlessApply`

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<img width="722" alt="image" src="https://github.com/user-attachments/assets/fd87ad2a-8f99-4231-ae3f-8a29b110bf9e">