### PR TITLE
feat: 채팅방 생성 및 게시물 작성자 자동 참여 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/auth/web/AuthController.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/web/AuthController.java
@@ -60,7 +60,7 @@ public class AuthController {
 
     @PostMapping(path = "/signup")
     public ResponseEntity<SignUpDto> signUp(
-            SignUpDto request,
+            @RequestPart(name = "request") SignUpDto request,
             @RequestPart(name = "image", required = false) MultipartFile image
     ) {
         authService.signUp(request, image);

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
@@ -7,10 +7,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMemberEntity, Long>,
-    CustomChatRoomMemberRepository {
+        CustomChatRoomMemberRepository {
 
-      List<ChatRoomMemberEntity> findByMember_Email(String email);
+    List<ChatRoomMemberEntity> findByMember_Email(String email);
 
-      List<ChatRoomMemberEntity> findByChatRoom_Id(Long chatRoomId);
-
+    List<ChatRoomMemberEntity> findByChatRoom_Id(Long chatRoomId);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomMemberService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomMemberService.java
@@ -1,0 +1,7 @@
+package connectripbe.connectrip_be.chat.service;
+
+public interface ChatRoomMemberService {
+
+    void jointChatRoom(Long chatRoomId, Long memberId);
+
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
@@ -9,4 +9,6 @@ public interface ChatRoomService {
       List<ChatRoomListResponse> getChatRoomList(Long memberId);
 
       List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId);
+
+      void createChatRoom(Long postId, Long memberId);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomMemberServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomMemberServiceImpl.java
@@ -1,0 +1,63 @@
+package connectripbe.connectrip_be.chat.service.impl;
+
+import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
+import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
+import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
+import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
+import connectripbe.connectrip_be.chat.repository.ChatRoomRepository;
+import connectripbe.connectrip_be.chat.service.ChatRoomMemberService;
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomMemberServiceImpl implements ChatRoomMemberService {
+
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberJpaRepository memberRepository;
+
+    /**
+     * 사용자를 특정 채팅방에 참여
+     * 채팅방과 사용자가 존재하는지 확인한 후, 사용자가 이미 채팅방에 참여 중인지 확인
+     * 참여하지 않은 경우 채팅방에 사용자를 추가하고, 참여한 경우 예외를 발생
+     *
+     * @param chatRoomId  참여할 채팅방의 ID
+     * @param memberId  참여할 사용자의 ID
+     * @throws GlobalException  채팅방이 존재하지 않거나, 사용자가 존재하지 않거나,
+     *                          사용자가 이미 채팅방에 참여한 경우 발생하는 예외
+     */
+    @Override
+    public void jointChatRoom(Long chatRoomId, Long memberId) {
+
+        // 채팅방이 존재하는지 확인
+        ChatRoomEntity chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 사용자가 존재하는지 확인
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미 채팅방에 참여중인지 확인
+        boolean isMemberAlreadyInRoom = chatRoom.getChatRoomMembers().stream()
+                .anyMatch(members -> members.getId().equals(memberId));
+
+        if (isMemberAlreadyInRoom) {
+            throw new GlobalException(ErrorCode.ALREADY_JOINED_CHAT_ROOM);
+        }
+
+        ChatRoomMemberEntity chatRoomMember = ChatRoomMemberEntity.builder()
+                .chatRoom(chatRoom)
+                .member(member)
+                .status(ChatRoomMemberStatus.ACTIVE)
+                .build();
+
+        chatRoom.addChatRoomMember(chatRoomMember);
+        chatRoomMemberRepository.save(chatRoomMember);
+
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
@@ -2,57 +2,96 @@ package connectripbe.connectrip_be.chat.service.impl;
 
 import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
 import connectripbe.connectrip_be.chat.dto.ChatRoomMemberResponse;
+import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
 
 import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
+import connectripbe.connectrip_be.chat.entity.type.ChatRoomType;
 import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
+import connectripbe.connectrip_be.chat.repository.ChatRoomRepository;
+import connectripbe.connectrip_be.chat.service.ChatRoomMemberService;
 import connectripbe.connectrip_be.chat.service.ChatRoomService;
 
 
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import connectripbe.connectrip_be.post.repository.AccompanyPostRepository;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ChatRoomServiceImpl implements ChatRoomService {
 
-      private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private static final Logger log = LoggerFactory.getLogger(ChatRoomServiceImpl.class);
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final AccompanyPostRepository accompanyPostRepository;
 
-      /**
-       * 사용자가 참여한 채팅방 목록을 조회하여 반환하는 메서드. 주어진 사용자의 이메일 주소를 기반으로 해당 사용자가 참여한 모든 채팅방을 조회
-       *
-       * @param memberId 사용자의 아이디. 이 이메일을 기반으로 해당 사용자가 참여한 채팅방을 조회
-       * @return 사용자가 참여한 채팅방의 목록을 포함하는 `List<ChatRoomListResponse>` 사용자가 참여한 채팅방이 없을 경우 빈 리스트를 반환
-       */
-      @Override
-      public List<ChatRoomListResponse> getChatRoomList(Long memberId) {
-            // 사용자 참여한 모든 ChatRoomMemberEntity 조회
-            List<ChatRoomMemberEntity> chatRoomMembers =  chatRoomMemberRepository.myChatRoomList(memberId);
+    private final ChatRoomMemberService chatRoomMemberService;
 
-            return chatRoomMembers.stream()
-                    .map(member -> ChatRoomListResponse.fromEntity(member.getChatRoom()))
-                    .toList();
-      }
+    /**
+     * 사용자가 참여한 채팅방 목록을 조회하여 반환하는 메서드. 주어진 사용자의 이메일 주소를 기반으로 해당 사용자가 참여한 모든 채팅방을 조회
+     *
+     * @param memberId 사용자의 아이디. 이 이메일을 기반으로 해당 사용자가 참여한 채팅방을 조회
+     * @return 사용자가 참여한 채팅방의 목록을 포함하는 `List<ChatRoomListResponse>` 사용자가 참여한 채팅방이 없을 경우 빈 리스트를 반환
+     */
+    @Override
+    public List<ChatRoomListResponse> getChatRoomList(Long memberId) {
+        // 사용자 참여한 모든 ChatRoomMemberEntity 조회
+        List<ChatRoomMemberEntity> chatRoomMembers = chatRoomMemberRepository.myChatRoomList(
+                memberId);
 
-      /**
-       * 주어진 채팅방의 참여자 목록을 조회하여 반환하는 메서드.
-       * 주어진 채팅방의 ID를 기반으로 해당 채팅방의 모든 참여자를 조회
-       *
-       * @param chatRoomId 채팅방의 ID. 이 ID를 기반으로 해당 채팅방의 참여자를 조회
-       * @return 채팅방의 참여자 목록을 포함하는 `List<ChatRoomMemberResponse>` 채팅방에 참여한 사용자가 없을 경우 빈 리스트를 반환
-       */
-      @Override
-      public List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId) {
+        return chatRoomMembers.stream()
+                .map(member -> ChatRoomListResponse.fromEntity(member.getChatRoom()))
+                .toList();
+    }
 
-            List<ChatRoomMemberEntity> chatRoomMembers = chatRoomMemberRepository.findByChatRoom_Id(
-                    chatRoomId);
+    /**
+     * 주어진 채팅방의 참여자 목록을 조회하여 반환하는 메서드. 주어진 채팅방의 ID를 기반으로 해당 채팅방의 모든 참여자를 조회
+     *
+     * @param chatRoomId 채팅방의 ID. 이 ID를 기반으로 해당 채팅방의 참여자를 조회
+     * @return 채팅방의 참여자 목록을 포함하는 `List<ChatRoomMemberResponse>` 채팅방에 참여한 사용자가 없을 경우 빈 리스트를 반환
+     */
+    @Override
+    public List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId) {
 
-            return chatRoomMembers.stream()
-                    .filter(member -> !Objects.equals(member.getStatus(),
-                            ChatRoomMemberStatus.EXIT))
-                    .map(ChatRoomMemberResponse::fromEntity)
-                    .toList();
-      }
+        List<ChatRoomMemberEntity> chatRoomMembers = chatRoomMemberRepository.findByChatRoom_Id(
+                chatRoomId);
+
+        return chatRoomMembers.stream()
+                .filter(member -> !Objects.equals(member.getStatus(),
+                        ChatRoomMemberStatus.EXIT))
+                .map(ChatRoomMemberResponse::fromEntity)
+                .toList();
+    }
+
+    /**
+     * 특정 게시물에 대한 채팅방을 생성하고, 게시물 작성자를 해당 채팅방에 자동으로 참여시킵니다.
+     *
+     * @param postId  채팅방을 생성할 게시물의 ID
+     * @param memberId  채팅방에 자동으로 참여시킬 게시물 작성자의 ID
+     * @throws GlobalException  게시물을 찾을 수 없는 경우 발생하는 예외
+     */
+    @Override
+    public void createChatRoom(Long postId, Long memberId) {
+        ChatRoomEntity chatRoom = ChatRoomEntity
+                .builder()
+                .accompanyPost(accompanyPostRepository.findById(postId)
+                        .orElseThrow(() -> new GlobalException(ErrorCode.POST_NOT_FOUND)))
+                .chatRoomType(ChatRoomType.ACTIVE)
+                .build();
+
+        // 채팅방 생성
+        chatRoomRepository.save(chatRoom);
+
+        // 채팅방에 게시물 작성자 자동 참여
+
+        chatRoomMemberService.jointChatRoom(chatRoom.getId(), memberId);
+
+    }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
@@ -19,15 +19,12 @@ import connectripbe.connectrip_be.post.repository.AccompanyPostRepository;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ChatRoomServiceImpl implements ChatRoomService {
 
-    private static final Logger log = LoggerFactory.getLogger(ChatRoomServiceImpl.class);
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final AccompanyPostRepository accompanyPostRepository;

--- a/src/main/java/connectripbe/connectrip_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/GlobalExceptionHandler.java
@@ -26,10 +26,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ErrorResponse exceptionHandler(Exception e) {
+    public ResponseEntity<ErrorResponse> exceptionHandler(Exception e) {
         log.error("Exception is occurred", e);
-        return new ErrorResponse(INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR,
-                INTERNAL_SERVER_ERROR.getDescription());
+        return new ResponseEntity<>(
+                new ErrorResponse(INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR,
+                        INTERNAL_SERVER_ERROR.getDescription()).getHttpStatus());
     }
 
 }

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -49,6 +49,9 @@ public enum ErrorCode {
     // Meeting error
     DUPLICATE_MEETING(HttpStatus.BAD_REQUEST, "이미 모임에 참여하셨습니다."),
 
+    // ChatRoom error
+    CHAT_ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 채팅방을 찾을 수 없습니다."),
+    ALREADY_JOINED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 참여한 채팅방입니다."),
     /**
      * 401 Unauthorized
      */

--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -31,6 +31,7 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     private final AccompanyStatusJpaRepository accompanyStatusJpaRepository;
 
     private final ChatRoomService chatRoomService;
+
     @Override
     @Transactional
     public void createAccompanyPost(Long memberId, CreateAccompanyPostRequest request) {
@@ -59,7 +60,6 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
 
         // 채팅방 생성 및 게시물 작성자 채팅방 자동 참여 처리
         chatRoomService.createChatRoom(post.getId(), memberId);
-
 
     }
 

--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -3,6 +3,7 @@ package connectripbe.connectrip_be.post.service.impl;
 import connectripbe.connectrip_be.accompany_status.entity.AccompanyStatusEntity;
 import connectripbe.connectrip_be.accompany_status.entity.AccompanyStatusEnum;
 import connectripbe.connectrip_be.accompany_status.repository.AccompanyStatusJpaRepository;
+import connectripbe.connectrip_be.chat.service.ChatRoomService;
 import connectripbe.connectrip_be.member.exception.MemberNotOwnerException;
 import connectripbe.connectrip_be.member.exception.NotFoundMemberException;
 import connectripbe.connectrip_be.post.dto.*;
@@ -29,7 +30,9 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     private final MemberJpaRepository memberJpaRepository;
     private final AccompanyStatusJpaRepository accompanyStatusJpaRepository;
 
+    private final ChatRoomService chatRoomService;
     @Override
+    @Transactional
     public void createAccompanyPost(Long memberId, CreateAccompanyPostRequest request) {
         MemberEntity memberEntity = findMemberEntity(memberId);
 
@@ -51,7 +54,13 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
                 .build();
 
         accompanyPostRepository.save(post);
-        accompanyStatusJpaRepository.save(new AccompanyStatusEntity(post, AccompanyStatusEnum.PROGRESSING));
+        accompanyStatusJpaRepository.save(
+                new AccompanyStatusEntity(post, AccompanyStatusEnum.PROGRESSING));
+
+        // 채팅방 생성 및 게시물 작성자 채팅방 자동 참여 처리
+        chatRoomService.createChatRoom(post.getId(), memberId);
+
+
     }
 
     @Override
@@ -63,7 +72,8 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     }
 
     @Override
-    public AccompanyPostResponse updateAccompanyPost(Long memberId, long id, UpdateAccompanyPostRequest request) {
+    public AccompanyPostResponse updateAccompanyPost(Long memberId, long id,
+            UpdateAccompanyPostRequest request) {
         MemberEntity memberEntity = findMemberEntity(memberId);
 
         AccompanyPostEntity accompanyPostEntity = findAccompanyPostEntity(id);
@@ -119,10 +129,12 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     }
 
     private AccompanyPostEntity findAccompanyPostEntity(long accompanyPostId) {
-        return accompanyPostRepository.findByIdAndDeletedAtIsNull(accompanyPostId).orElseThrow(NotFoundAccompanyPostException::new);
+        return accompanyPostRepository.findByIdAndDeletedAtIsNull(accompanyPostId)
+                .orElseThrow(NotFoundAccompanyPostException::new);
     }
 
-    private void validateAccompanyPostOwnership(MemberEntity memberEntity, AccompanyPostEntity accompanyPostEntity) {
+    private void validateAccompanyPostOwnership(MemberEntity memberEntity,
+            AccompanyPostEntity accompanyPostEntity) {
         if (!memberEntity.getId().equals(accompanyPostEntity.getMemberEntity().getId())) {
             throw new MemberNotOwnerException();
         }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 게시물 작성자가 게시물을 생성할 때, 자동으로 해당 게시물에 대한 채팅방을 생성하고 작성자를 채팅방에 자동으로 참여시키는 기능이 없음.

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 -->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- **채팅방 생성 및 작성자 자동 참여 기능 추가**:
  - `ChatRoomService`와 `ChatRoomMemberService`에서 게시물 생성 시 채팅방을 자동으로 생성하고, 게시물 작성자를 채팅방에 자동으로 참여시키는 로직을 추가
  - `AccompanyPostServiceImpl`에서 게시물 생성 후, `ChatRoomService.createChatRoom`을 호출하여 해당 게시물에 대한 채팅방을 생성하고 작성자를 참여

- **에러 처리 및 리팩토링**:
  - 채팅방 관련 에러 코드 `CHAT_ROOM_NOT_FOUND`와 `ALREADY_JOINED_CHAT_ROOM`을 추가하여 예외 상황을 명확하게 처리하도록 했습니다.
  - `GlobalExceptionHandler`에서 발생할 수 있는 일반적인 예외에 대해 일관된 HTTP 응답을 반환하도록 리팩토링했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
> 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드 작성
- [ ] API 테스트 진행