### PR TITLE
hotfix: 동행 게시글 갱신 중 빠진 customUrl 파라미터 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/post/dto/UpdateAccompanyPostRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/UpdateAccompanyPostRequest.java
@@ -1,6 +1,5 @@
 package connectripbe.connectrip_be.post.dto;
 
-import connectripbe.connectrip_be.post.entity.enums.AccompanyArea;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -11,6 +10,7 @@ public record UpdateAccompanyPostRequest(
         String content,
         String accompanyArea,
         LocalDateTime startDate,
-        LocalDateTime endDate
+        LocalDateTime endDate,
+        String customUrl
 ) {
 }

--- a/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
@@ -58,12 +58,12 @@ public class AccompanyPostEntity extends BaseEntity {
         this.content = content;
     }
 
-    public void updateAccompanyPost(String title, LocalDateTime startDate, LocalDateTime endDate, String accompanyArea, String content) {
+    public void updateAccompanyPost(String title, LocalDateTime startDate, LocalDateTime endDate, String accompanyArea, String content, String customUrl) {
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;
         this.accompanyArea = accompanyArea;
         this.content = content;
+        this.customUrl = customUrl;
     }
-
 }

--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -85,7 +85,8 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
                 request.startDate(),
                 request.endDate(),
                 request.accompanyArea(),
-                request.content()
+                request.content(),
+                request.customUrl()
         );
 
         // 수정된 데이터를 응답으로 반환


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 동행 게시글 수정 중 customUrl 필드가 없어서 예외 발생

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- customUrl 필드 관련 로직 수정

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 