### PR TITLE
refactor: PendingStatus enum 상태값 업데이트

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/pending_list/entity/PendingListEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/entity/PendingListEntity.java
@@ -50,11 +50,11 @@ public class PendingListEntity extends BaseEntity {
     }
 
     public void acceptStatus() {
-        this.status = PendingStatus.ACCEPT;
+        this.status = PendingStatus.ACCEPTED;
     }
 
     public void rejectStatus() {
-        this.status = PendingStatus.REJECT;
+        this.status = PendingStatus.REJECTED;
     }
 
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/entity/type/PendingStatus.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/entity/type/PendingStatus.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 public enum PendingStatus {
 
     PENDING("대기중"),
-    ACCEPT("수락"),
-    REJECT("거절");
+    ACCEPTED("수락"),
+    REJECTED("거절");
 
     private final String message;
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ]  신청 목록 상태값이 프론트와 다른 휴먼 에러 발생 

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 'ACCEPT'와 'REJECT'를 'ACCEPTED'와 'REJECTED'로 변경했습니다.
- PendingListEntity 클래스의 관련 메서드에서 수정된 enum 값을 반영했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 