### PR TITLE
feat: 채팅방 나가기 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
@@ -37,6 +37,11 @@ public class ChatRoomEntity extends BaseEntity {
       @JoinColumn(name = "accompany_post_id")
       private AccompanyPostEntity accompanyPost;
 
+      // 방장 설정: ChatRoomMember의 ID를 참조
+      @OneToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "leader_id")
+      private ChatRoomMemberEntity currentLeader;
+
       @Enumerated(EnumType.STRING)
       private ChatRoomType chatRoomType;
 
@@ -57,6 +62,18 @@ public class ChatRoomEntity extends BaseEntity {
       public void addChatRoomMember(ChatRoomMemberEntity chatRoomMember) {
             this.chatRoomMembers.add(chatRoomMember);
             chatRoomMember.assignChatRoom(this);
+      }
+
+      // 방장 설정 메서드 (초기 방장 설정)
+      public void setInitialLeader(ChatRoomMemberEntity leader) {
+            this.currentLeader = leader;
+            this.addChatRoomMember(leader);
+      }
+
+
+      // 채팅방 상태 변경 메서드
+      public void changeChatRoomType(ChatRoomType chatRoomType) {
+            this.chatRoomType = chatRoomType;
       }
 
       //TODO 마지막 채팅 메시지 및 시간 업데이트 메서드

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
@@ -1,7 +1,9 @@
 package connectripbe.connectrip_be.chat.repository;
 
 import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
+import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +14,11 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMemberEn
     List<ChatRoomMemberEntity> findByMember_Email(String email);
 
     List<ChatRoomMemberEntity> findByChatRoom_Id(Long chatRoomId);
+
+    Optional<ChatRoomMemberEntity> findByChatRoom_IdAndMember_Id(Long id, Long memberId);
+
+    Integer countByChatRoom_IdAndStatus(Long chatRoomId, ChatRoomMemberStatus chatRoomMemberStatus);
+
+    Optional<ChatRoomMemberEntity> findFirstByChatRoom_IdAndStatusOrderByCreatedAt(Long chatRoomId,
+            ChatRoomMemberStatus chatRoomMemberStatus);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
@@ -11,4 +11,6 @@ public interface ChatRoomService {
       List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId);
 
       void createChatRoom(Long postId, Long memberId);
+
+      void exitChatRoom(Long chatRoomId, Long id);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,5 +32,15 @@ public class ChatRoomController {
               @PathVariable Long chatRoomId
       ) {
             return ResponseEntity.ok(chatRoomService.getChatRoomMembers(chatRoomId));
+      }
+
+      // 해당 채팅방 나가기
+      @PostMapping("/{chatRoomId}/exit")
+      public ResponseEntity<?> exitChatRoom(
+              @PathVariable Long chatRoomId,
+              @AuthenticationPrincipal Long memberId
+      ) {
+            chatRoomService.exitChatRoom(chatRoomId, memberId);
+            return ResponseEntity.ok("채팅방 나가기 완료");
       }
 }

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -74,7 +74,7 @@ public enum ErrorCode {
      */
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이메일로 사용자를 찾을 수 없습니다."),
-
+    CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방 참여자를 찾을 수 없습니다."),
     /**
      * 409 Conflict
      */


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 사용자들이 채팅방에서 나가고자 할 때, 해당 기능이 부족하여 불편함이 있었습니다. 
- 특히, 방장이 나가거나 마지막 멤버가 나갈 때의 처리가 미비하여 문제를 일으킬 수 있었습니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 -->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- **채팅방 나가기 기능 추가**:
  - 사용자가 채팅방을 나갈 수 있는 기능을 추가했습니다.
  - 사용자가 나가면 해당 사용자의 상태를 '나감'으로 업데이트하며, 방장이 나가는 경우에는 방장 권한을 다른 멤버에게 자동으로 승계합니다.
  - 마지막 멤버가 나가는 경우, 채팅방의 상태를 '삭제됨'으로 변경하도록 처리했습니다.

- **채팅방 관련 엔티티 및 레포지토리 업데이트**:
  - `ChatRoomEntity`에 방장(`currentLeader`) 필드를 추가하고, 방장 설정 메서드를 구현했습니다.
  - `ChatRoomMemberRepository`에 방장 승계를 위한 멤버 조회 메서드를 추가했습니다.

- **예외 처리 및 에러 코드 추가**:
  - 방장 승계 중 문제가 발생하거나, 사용자가 존재하지 않는 경우를 처리하기 위한 예외 처리를 추가하고, 이에 대한 에러 코드를 정의했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
> 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드 작성
- [x] API 테스트 진행

이 PR은 채팅방에서 사용자가 나갈 때 발생할 수 있는 다양한 시나리오를 처리하여, 채팅방 기능의 안정성과 사용자 편의성을 크게 향상시켰습니다.