### PR TITLE
hotfix- 게시물 현재 상태 응답 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostResponse.java
@@ -24,7 +24,7 @@ public record AccompanyPostResponse(
         String createdAt
 ) {
 
-    public static AccompanyPostResponse fromEntity(AccompanyPostEntity accompanyPost) {
+    public static AccompanyPostResponse fromEntity(AccompanyPostEntity accompanyPost, String status) {
 
         return AccompanyPostResponse.builder()
                 .id(accompanyPost.getId())
@@ -38,7 +38,7 @@ public record AccompanyPostResponse(
                 .customUrl(accompanyPost.getCustomUrl())
                 .urlQrPath(accompanyPost.getUrlQrPath())
                 .content(accompanyPost.getContent())
-                .status(accompanyPost.getRequestStatus())
+                .status(status)
                 .createdAt(formatToUTC(accompanyPost.getCreatedAt()))
                 .build();
 

--- a/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
@@ -43,9 +43,6 @@ public class AccompanyPostEntity extends BaseEntity {
     private String content;
 
     // fixme-eric 동행 요청 상태 임시보류
-    @Column(name = "request_status")
-    @Builder.Default
-    private String requestStatus = "DEFAULT";
 
     public AccompanyPostEntity(MemberEntity memberEntity, String title, LocalDateTime startDate, LocalDateTime endDate, String accompanyArea, String customUrl, String urlQrPath, String content) {
         this.memberEntity = memberEntity;

--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -51,7 +51,6 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
                 .accompanyArea(request.accompanyArea())
                 .urlQrPath("temp")
                 .customUrl(request.customUrl())
-                .requestStatus("DEFAULT")
                 .build();
 
         accompanyPostRepository.save(post);
@@ -67,8 +66,12 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     @Transactional(readOnly = true)
     public AccompanyPostResponse readAccompanyPost(long id) {
         AccompanyPostEntity accompanyPostEntity = findAccompanyPostEntity(id);
+        AccompanyStatusEntity accompanyStatusEntity = accompanyStatusJpaRepository
+                .findTopByAccompanyPostEntityOrderByCreatedAtDesc(accompanyPostEntity)
+                .orElseThrow(NotFoundAccompanyPostException::new);
 
-        return AccompanyPostResponse.fromEntity(accompanyPostEntity);
+        return AccompanyPostResponse.fromEntity(accompanyPostEntity,
+                accompanyStatusEntity.getAccompanyStatusEnum().toString());
     }
 
     @Override
@@ -80,6 +83,10 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
 
         validateAccompanyPostOwnership(memberEntity, accompanyPostEntity);
 
+        AccompanyStatusEntity accompanyStatusEntity = accompanyStatusJpaRepository
+                .findTopByAccompanyPostEntityOrderByCreatedAtDesc(accompanyPostEntity)
+                .orElseThrow(NotFoundAccompanyPostException::new);
+
         accompanyPostEntity.updateAccompanyPost(
                 request.title(),
                 request.startDate(),
@@ -90,7 +97,8 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
         );
 
         // 수정된 데이터를 응답으로 반환
-        return AccompanyPostResponse.fromEntity(accompanyPostEntity);
+        return AccompanyPostResponse.fromEntity(accompanyPostEntity, accompanyStatusEntity
+                .getAccompanyStatusEnum().toString());
     }
 
     @Override


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 게시물의 상태를 정확히 반영하지 못하는 문제를 해결하기 위해, 게시물의 현재 상태를 올바르게 응답하도록 수정하였습니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- **게시물 상태 처리 개선**:
  - `AccompanyPostResponse`의 상태(`status`) 필드가 더 이상 엔티티의 `requestStatus` 값을 사용하지 않고, 관련된 `AccompanyStatusEntity`의 최신 상태 값을 사용하도록 변경되었습니다.
  - `AccompanyPostServiceImpl` 클래스에서 게시물 조회 및 업데이트 시, 최신 상태를 가져와 응답에 반영하도록 로직을 수정했습니다.
  - 불필요한 `requestStatus` 필드를 `AccompanyPostEntity`에서 제거하였습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없음

### 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트 진행
