### PR TITLE
feat: 채팅방 나감 상태 및 관련 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatMessage.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatMessage.java
@@ -1,0 +1,26 @@
+package connectripbe.connectrip_be.chat.entity;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "chat_message")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatMessage {
+
+    @Id
+    private String id;
+
+    @Field("chat_room_id")
+    private Long chatRoomId;
+
+    @Field("sender_id")
+    private Long senderId;
+
+
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
@@ -19,6 +19,7 @@ public class ChatRoomController {
 
       private final ChatRoomService chatRoomService;
 
+      // 채팅방 목록 조회
       @GetMapping("/list")
       public ResponseEntity<List<ChatRoomListResponse>> getChatRoomList(
               @AuthenticationPrincipal Long memberId

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -73,6 +73,7 @@ public enum ErrorCode {
      * 404 Not Found
      */
 
+    PENDING_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 신청 목록을 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이메일로 사용자를 찾을 수 없습니다."),
     CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방 참여자를 찾을 수 없습니다."),
     /**

--- a/src/main/java/connectripbe/connectrip_be/pending_list/entity/PendingListEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/entity/PendingListEntity.java
@@ -49,12 +49,8 @@ public class PendingListEntity extends BaseEntity {
         this.status = PendingStatus.PENDING;
     }
 
-    public void acceptStatus() {
-        this.status = PendingStatus.ACCEPTED;
-    }
-
-    public void rejectStatus() {
-        this.status = PendingStatus.REJECTED;
+    public void updateStatus(PendingStatus status) {
+        this.status = status;
     }
 
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/entity/type/PendingStatus.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/entity/type/PendingStatus.java
@@ -9,7 +9,9 @@ public enum PendingStatus {
 
     PENDING("대기중"),
     ACCEPTED("수락"),
-    REJECTED("거절");
+    REJECTED("거절"),
+    EXIT_ROOM("나감")
+    ;
 
     private final String message;
 }


### PR DESCRIPTION
### PR 제목
**feat: 채팅방 나가기 처리 및 PendingList 상태 업데이트 기능 추가**

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 현재 채팅방에서 사용자가 나갈 때, 관련된 `PendingList`의 상태가 업데이트되지 않는 문제

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 -->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 
- **채팅방 나가기 기능 강화**:
  - `ChatRoomServiceImpl`에 채팅방에서 사용자가 나갈 때, `PendingList`의 상태를 `EXIT_ROOM`으로 업데이트하는 로직을 추가했습니다.
  - 방장이 아닌 일반 사용자가 나갈 때만 `PendingList`의 상태를 업데이트하도록 구현했습니다.

- **PendingList 상태 업데이트**:
  - `PendingListEntity`에 `updateStatus(PendingStatus status)` 메서드를 추가하여 상태를 유연하게 변경할 수 있도록 리팩토링했습니다.
  - 새로운 상태 `EXIT_ROOM`을 `PendingStatus`에 추가하여 채팅방을 나간 사용자의 상태를 명확하게 구분할 수 있게 했습니다.

- **에러 처리 개선**:
  - `ErrorCode`에 `PENDING_LIST_NOT_FOUND` 예외를 추가하여, `PendingList`가 존재하지 않을 경우 적절한 예외를 발생시키도록 했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
> 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드 작성
- [ ] API 테스트 진행

이 PR은 채팅방에서 사용자가 나갈 때 발생할 수 있는 여러 문제를 해결하고, `PendingList` 상태를 정확하게 유지하여 사용자 경험을 향상시키는 데 목적이 있습니다.