### PR TITLE
fix: 채팅방 ID를 동반 게시물 응답에 포함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,14 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    
+    // MongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+    // RabbitMQ
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    // STOMP
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
@@ -2,9 +2,12 @@ package connectripbe.connectrip_be.chat.repository;
 
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
+
+    Optional<ChatRoomEntity> findByAccompanyPost_Id(long id);
 }

--- a/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostResponse.java
@@ -1,5 +1,6 @@
 package connectripbe.connectrip_be.post.dto;
 
+import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
 import lombok.Builder;
 
@@ -11,6 +12,7 @@ import java.time.format.DateTimeFormatter;
 public record AccompanyPostResponse(
         Long id,
         Long memberId,
+        Long leaderId,
         String nickname,
         String profileImagePath,
         String title,
@@ -24,11 +26,13 @@ public record AccompanyPostResponse(
         String createdAt
 ) {
 
-    public static AccompanyPostResponse fromEntity(AccompanyPostEntity accompanyPost, String status) {
+    public static AccompanyPostResponse fromEntity(AccompanyPostEntity accompanyPost, String status
+            , ChatRoomEntity chatRoom) {
 
         return AccompanyPostResponse.builder()
                 .id(accompanyPost.getId())
                 .memberId(accompanyPost.getMemberEntity().getId())
+                .leaderId(chatRoom.getCurrentLeader().getMember().getId())
                 .nickname(accompanyPost.getMemberEntity().getNickname())
                 .profileImagePath(accompanyPost.getMemberEntity().getProfileImagePath())
                 .title(accompanyPost.getTitle())
@@ -44,7 +48,8 @@ public record AccompanyPostResponse(
 
     }
 
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     private static String formatToUTC(LocalDateTime dateTime) {
         if (dateTime == null) {


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 동반 게시물 조회 시, 해당 게시물과 연결된 채팅방의 정보를 함께 제공하여 사용자가 관련된 채팅방에 쉽게 접근

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 -->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요 

- **채팅방 ID 포함**:
  - `AccompanyPostResponse`에 `leaderId` 필드를 추가하여 게시물의 작성자가 해당 채팅방의 리더임을 명확히 표시했습니다.
  - 채팅방 조회 시 해당 채팅방의 리더 정보를 동반 게시물 응답에 포함시키도록 수정했습니다.
  - `ChatRoomRepository`에 `findByAccompanyPost_Id` 메서드를 추가하여, 게시물 ID를 기반으로 채팅방을 조회할 수 있도록 했습니다.

- **MongoDB 및 RabbitMQ 라이브러리 추가**:
  - `build.gradle`에 MongoDB와 RabbitMQ 관련 의존성을 추가하여, NoSQL 데이터베이스와 비동기 메시징 큐를 사용할 수 있도록 설정했습니다.
  - MongoDB를 사용하여 채팅 메시지를 저장할 수 있도록 `ChatMessage` 엔티티를 추가했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
> 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드 작성
- [x] API 테스트 진행

이 PR은 동반 게시물과 관련된 채팅방의 정보를 효과적으로 제공하여 사용자 경험을 개선하고, 향후 MongoDB와 RabbitMQ를 사용한 확장 가능성을 열어두는 데 목적이 있습니다.