### PR TITLE
fix: 채팅방 나가기 시 pendingList 업데이트 및 활성 멤버 수 계산 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
@@ -2,6 +2,7 @@ package connectripbe.connectrip_be.chat.dto;
 
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 
+import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -28,6 +29,11 @@ public record ChatRoomListResponse(
                 ? chatRoom.getLastChatTime()
                 : chatRoom.getCreatedAt();
 
+        // 활성 멤버 수 계산
+        int activeMemberCnt = (int) chatRoom.getChatRoomMembers().stream()
+                .filter(member -> member.getStatus().equals(ChatRoomMemberStatus.ACTIVE))
+                .count();
+
         return ChatRoomListResponse.builder()
                 .chatRoomId(chatRoom.getId())
                 .accompanyPostId(chatRoom.getAccompanyPost().getId())
@@ -37,7 +43,7 @@ public record ChatRoomListResponse(
                 .endDate(formatToUTC(chatRoom.getAccompanyPost().getEndDate()))
                 .lastChatMessage(chatRoom.getLastChatMessage())
                 .lastChatMessageTime(formatToUTC(lastChatTime))
-                .memberNumber(chatRoom.getChatRoomMembers().size())
+                .memberNumber(activeMemberCnt)
                 .build();
     }
 

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
@@ -130,6 +130,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         // 사용자가 존재하는지 확인
         ChatRoomMemberEntity chatRoomMember = getRoomMember(chatRoomId, memberId);
 
+        // 채팅방에서 나가기 전 pendingList 업데이트
+        pendingListUpdate(chatRoomMember, chatRoom);
+
         // 사용자가 채팅방에서 나가기
         chatRoomMember.exitChatRoom();
 
@@ -163,12 +166,13 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         chatRoomRepository.save(chatRoom);
 
+    }
+
+    private void pendingListUpdate(ChatRoomMemberEntity chatRoomMember, ChatRoomEntity chatRoom) {
         AccompanyPostEntity accompanyPost = chatRoomMember.getChatRoom().getAccompanyPost();
 
         // 방장이 아닌 경우에만 pendingList 업데이트
         if (!chatRoomMember.getMember().equals(chatRoom.getCurrentLeader().getMember())) {
-
-            // 채팅방 나가기 처리 후, 방장이 아닌 일반 사용자가 참여한 pendingList EXIT_ROOM 으로 변경
             PendingListEntity pendingMember = pendingListRepository.findByAccompanyPostAndMember(
                             accompanyPost, chatRoomMember.getMember())
                     .orElseThrow(() -> new GlobalException(ErrorCode.PENDING_LIST_NOT_FOUND));


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요

- 채팅방에서 사용자가 나갈 때, 해당 사용자의 상태를 올바르게 반영하기 위해 `pendingList`의 상태를 업데이트
- 채팅방의 활성 멤버 수를 정확하게 계산.

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- **채팅방 나가기 시 `pendingList` 업데이트**:
  - 사용자가 채팅방에서 나갈 때, `pendingList`의 상태를 `EXIT_ROOM`으로 업데이트하도록 수정
  - 이 업데이트는 방장이 아닌 일반 사용자가 채팅방을 나갈 때에만 적용되며, 사용자의 상태를 정확히 반영하도록 합니다.

- **활성 멤버 수 계산 수정**:
  - 채팅방의 멤버 수를 계산할 때, 모든 멤버가 아닌 `ACTIVE` 상태의 멤버만을 계산하도록 변경.
  - 이를 통해 채팅방의 활성 멤버 수를 정확하게 반영

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드 작성
- [x] API 테스트 진행
