### PR TITLE
feat: 채팅방 방장이 신청자 목록 조회 기능 추가 및 PendingResponse 리팩토링

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/comment/entity/AccompanyCommentEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/entity/AccompanyCommentEntity.java
@@ -17,6 +17,7 @@ public class AccompanyCommentEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private MemberEntity memberEntity;  // 사용자 아이디 (외래키)

--- a/src/main/java/connectripbe/connectrip_be/comment/repository/AccompanyCommentRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/repository/AccompanyCommentRepository.java
@@ -10,6 +10,6 @@ public interface AccompanyCommentRepository extends JpaRepository<AccompanyComme
 
     Optional<AccompanyCommentEntity> findByIdAndDeletedAtIsNull(long id);
 
-    // AccompanyPostEntity의 ID로 삭제되지 않은 댓글 목록 조회
+    // AccompanyPostEntity 의 ID로 삭제되지 않은 댓글 목록 조회
     List<AccompanyCommentEntity> findByAccompanyPostEntity_IdAndDeletedAtIsNull(Long postId);
 }

--- a/src/main/java/connectripbe/connectrip_be/comment/service/impl/AccompanyCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/service/impl/AccompanyCommentServiceImpl.java
@@ -27,8 +27,8 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
 
     /**
      * 댓글을 생성하는 메서드.
-     * 사용자 이메일을 통해 MemberEntity를 조회하고, 게시물 ID를 통해 AccompanyPostEntity를 조회한 후
-     * AccompanyCommentEntity를 생성하여 데이터베이스에 저장
+     * 사용자 이메일을 통해 MemberEntity 를 조회하고, 게시물 ID를 통해 AccompanyPostEntity 를 조회한 후
+     * AccompanyCommentEntity 를 생성하여 데이터베이스에 저장
      *
      * @param memberId 댓글 작성자의 아이디
      * @param request  댓글 생성 요청 정보 (게시물 ID, 댓글 내용 포함)
@@ -110,7 +110,7 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
 
     /**
      * 주어진 댓글 ID로 댓글을 조회하는 메서드.
-     * 만약 해당 댓글이 존재하지 않으면 GlobalException을 발생
+     * 만약 해당 댓글이 존재하지 않으면 GlobalException 을 발생
      *
      * @param commentId 조회할 댓글의 ID
      * @return 조회된 AccompanyCommentEntity 객체

--- a/src/main/java/connectripbe/connectrip_be/global/exception/GlobalException.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/GlobalException.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @Getter
 public class GlobalException extends RuntimeException {
 
-      private final ErrorCode errorCode;
+    private final ErrorCode errorCode;
 
-      public GlobalException(ErrorCode errorCode) {
+    public GlobalException(ErrorCode errorCode) {
         super(errorCode.getDescription());
         this.errorCode = errorCode;
-      }
+    }
 }

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -18,7 +18,6 @@ public enum ErrorCode {
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
     WRITE_NOT_YOURSELF(HttpStatus.BAD_REQUEST, "본인이 작성한 글만 수정 또는 삭제할 수 있습니다."),
-    POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
     PROFILE_IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "프로필 이미지 업로드 중 오류가 발생했습니다."),
     POST_IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "게시물 이미지 업로드 중 오류가 발생했습니다."),
@@ -50,7 +49,6 @@ public enum ErrorCode {
     DUPLICATE_MEETING(HttpStatus.BAD_REQUEST, "이미 모임에 참여하셨습니다."),
 
     // ChatRoom error
-    CHAT_ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 채팅방을 찾을 수 없습니다."),
     ALREADY_JOINED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 참여한 채팅방입니다."),
     /**
      * 401 Unauthorized
@@ -76,6 +74,9 @@ public enum ErrorCode {
     PENDING_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 신청 목록을 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이메일로 사용자를 찾을 수 없습니다."),
     CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방 참여자를 찾을 수 없습니다."),
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방을 찾을 수 없습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 글을 찾을 수 없습니다."),
+
     /**
      * 409 Conflict
      */

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode {
     PENDING_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 신청을 찾을 수 없습니다."),
     PENDING_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 신청한 상태입니다."),
     WRITE_YOURSELF(HttpStatus.BAD_REQUEST, "본인이 작성한 글은 신청할 수 없습니다."),
-
+    NOT_CHATROOM_LEADER(HttpStatus.BAD_REQUEST, "채팅방 방장이 아닙니다."),
     // Member, 사용자
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATE_MEMBER_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
@@ -76,6 +76,7 @@ public enum ErrorCode {
     CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방 참여자를 찾을 수 없습니다."),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방을 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 글을 찾을 수 없습니다."),
+    CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방을 찾을 수 없습니다."),
 
     /**
      * 409 Conflict

--- a/src/main/java/connectripbe/connectrip_be/global/util/aws/service/AwsS3Service.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/aws/service/AwsS3Service.java
@@ -8,7 +8,6 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,74 +23,73 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class AwsS3Service {
 
-      private final AmazonS3 amazonS3;
+    private final AmazonS3 amazonS3;
 
-      @Value("${cloud.aws.s3.bucket}")
-      private String bucketName;
-
-
-      /**
-       * AWS S3에 파일을 업로드.
-       *
-       * @param multipartFile 업로드할 파일
-       * @param fileName      파일 이름
-       */
-      public void uploadToS3(MultipartFile multipartFile, String fileName) {
-            log.info("[uploadToS3] 시작");
-            try (InputStream inputStream = multipartFile.getInputStream()) {
-                  log.info("[uploadToS3] inputStream: {}", inputStream);
-                  amazonS3.putObject(new PutObjectRequest(bucketName, fileName, inputStream,
-                          getObjectMetadata(multipartFile))
-                          .withCannedAcl(CannedAccessControlList.PublicRead));
-                  log.info("[uploadToS3] 업로드 성공");
-            } catch (IOException e) {
-                  log.error("IOException이 발생했습니다", e);
-                  throw new GlobalException(INTERNAL_SERVER_ERROR);
-            } catch (AmazonS3Exception e) {
-                  log.error("AmazonS3Exception이 발생했습니다", e);
-                  throw new GlobalException(INTERNAL_SERVER_ERROR);
-            } catch (Exception e) {
-                  log.error("예상치 못한 예외가 발생했습니다", e);
-                  throw new GlobalException(INTERNAL_SERVER_ERROR);
-            }
-      }
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
 
 
-      public void deleteFile(String fileName) {
-            try {
-                  amazonS3.deleteObject(bucketName, fileName);
-            } catch (AmazonS3Exception e) {
-                  log.error("AmazonS3Exception is occurred", e);
-                  throw new GlobalException(INTERNAL_SERVER_ERROR);
-            }
-      }
+    /**
+     * AWS S3에 파일을 업로드.
+     *
+     * @param multipartFile 업로드할 파일
+     * @param fileName      파일 이름
+     */
+    public void uploadToS3(MultipartFile multipartFile, String fileName) {
+        log.info("[uploadToS3] 시작");
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            log.info("[uploadToS3] inputStream: {}", inputStream);
+            amazonS3.putObject(new PutObjectRequest(bucketName, fileName, inputStream,
+                    getObjectMetadata(multipartFile)).withCannedAcl(CannedAccessControlList.PublicRead));
+            log.info("[uploadToS3] 업로드 성공");
+        } catch (IOException e) {
+            log.error("IOException이 발생했습니다", e);
+            throw new GlobalException(INTERNAL_SERVER_ERROR);
+        } catch (AmazonS3Exception e) {
+            log.error("AmazonS3Exception이 발생했습니다", e);
+            throw new GlobalException(INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error("예상치 못한 예외가 발생했습니다", e);
+            throw new GlobalException(INTERNAL_SERVER_ERROR);
+        }
+    }
 
-      public String getUrl(String fileName) {
-            return amazonS3.getUrl(bucketName, fileName).toString();
-      }
 
-      public ObjectMetadata getObjectMetadata(MultipartFile multipartFile) {
-            ObjectMetadata objectMetadata = new ObjectMetadata();
-            objectMetadata.setContentType(multipartFile.getContentType());
-            objectMetadata.setContentLength(multipartFile.getSize());
-            return objectMetadata;
-      }
+    public void deleteFile(String fileName) {
+        try {
+            amazonS3.deleteObject(bucketName, fileName);
+        } catch (AmazonS3Exception e) {
+            log.error("AmazonS3Exception is occurred", e);
+            throw new GlobalException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public String getUrl(String fileName) {
+        return amazonS3.getUrl(bucketName, fileName).toString();
+    }
+
+    public ObjectMetadata getObjectMetadata(MultipartFile multipartFile) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+        objectMetadata.setContentLength(multipartFile.getSize());
+        return objectMetadata;
+    }
 
 
-      public String generateFileName(MultipartFile multipartFile) {
-            return UUID.randomUUID().toString() + "_" + multipartFile.getOriginalFilename();
-      }
+    public String generateFileName(MultipartFile multipartFile) {
+        return UUID.randomUUID().toString() + "_" + multipartFile.getOriginalFilename();
+    }
 
 
-      // URL 을 사용하여 파일을 삭제하는 메서드
-      public void deleteFilesUsingUrl(String fileUrl) {
+    // URL 을 사용하여 파일을 삭제하는 메서드
+    public void deleteFilesUsingUrl(String fileUrl) {
 
-            String fileName = extractFileNameFromUrl(fileUrl);
-            deleteFile(fileName); // 기존에 작성한 deleteFile 메서드를 재사용
-      }
+        String fileName = extractFileNameFromUrl(fileUrl);
+        deleteFile(fileName); // 기존에 작성한 deleteFile 메서드를 재사용
+    }
 
-      public String extractFileNameFromUrl(String fileUrl) {
-            return fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
-      }
+    public String extractFileNameFromUrl(String fileUrl) {
+        return fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+    }
 
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingListResponse.java
@@ -1,0 +1,23 @@
+package connectripbe.connectrip_be.pending_list.dto;
+
+import connectripbe.connectrip_be.pending_list.entity.PendingListEntity;
+import lombok.Builder;
+
+@Builder
+public record PendingListResponse(
+
+        Long accompanyPostId,
+        Long memberId,
+        String memberNickname,
+        String profileImagePath
+) {
+    public static PendingListResponse fromEntity(PendingListEntity pending) {
+
+        return PendingListResponse.builder()
+                .accompanyPostId(pending.getAccompanyPost().getId())
+                .memberId(pending.getMember().getId())
+                .memberNickname(pending.getMember().getNickname())
+                .profileImagePath(pending.getMember().getProfileImagePath())
+                .build();
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingResponse.java
@@ -1,10 +1,9 @@
 package connectripbe.connectrip_be.pending_list.dto;
 
-import connectripbe.connectrip_be.pending_list.entity.type.PendingStatus;
 import lombok.Builder;
 
 @Builder
-public record PendingListResponse(
+public record PendingResponse(
         String status
 ) {
 

--- a/src/main/java/connectripbe/connectrip_be/pending_list/repository/PendingListRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/repository/PendingListRepository.java
@@ -3,6 +3,7 @@ package connectripbe.connectrip_be.pending_list.repository;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.pending_list.entity.PendingListEntity;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,7 +12,9 @@ import org.springframework.stereotype.Repository;
 public interface PendingListRepository extends JpaRepository<PendingListEntity, Long> {
 
     Optional<PendingListEntity> findByAccompanyPostAndMember(AccompanyPostEntity accompanyPost,
-            MemberEntity member);
+                                                             MemberEntity member);
 
     boolean existsByMemberAndAccompanyPost(MemberEntity member, AccompanyPostEntity accompanyPost);
+
+    List<PendingListEntity> findByAccompanyPost(AccompanyPostEntity accompanyPost);
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface PendingListService {
 
-    //TODO 게시물 작성자가 해당 게시물에 신청한 사용자들의 리스트를 조회하는 api
+    // 게시물 작성자가 해당 게시물에 신청한 사용자들의 리스트를 조회하는 api
     // - 게시물 작성자 or 채팅방 방장만 볼 수 있음, 신청 또는 수락이 된다면 리스트에 출력 X
     List<PendingListResponse> getPendingList(Long memberId, Long accompanyPostId);
 

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
@@ -1,13 +1,15 @@
 package connectripbe.connectrip_be.pending_list.service;
 
 
+import connectripbe.connectrip_be.pending_list.dto.PendingListResponse;
 import connectripbe.connectrip_be.pending_list.dto.PendingResponse;
+import java.util.List;
 
 public interface PendingListService {
 
     //TODO 게시물 작성자가 해당 게시물에 신청한 사용자들의 리스트를 조회하는 api
-    // - 게시물 작성자만 볼 수 있음, 신청 또는 수락이 된다면 리스트에 출력 X
-
+    // - 게시물 작성자 or 채팅방 방장만 볼 수 있음, 신청 또는 수락이 된다면 리스트에 출력 X
+    List<PendingListResponse> getPendingList(Long memberId, Long accompanyPostId);
 
     // 현재 로그인 한 사용자가 게시물에 신청된 상태 확인 api
     PendingResponse getMyPendingStatus(Long memberId, Long accompanyPostId);

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
@@ -1,15 +1,31 @@
 package connectripbe.connectrip_be.pending_list.service;
 
 
-import connectripbe.connectrip_be.pending_list.dto.PendingListResponse;
+import connectripbe.connectrip_be.pending_list.dto.PendingResponse;
 
 public interface PendingListService {
 
     //TODO 게시물 작성자가 해당 게시물에 신청한 사용자들의 리스트를 조회하는 api
+    // - 게시물 작성자만 볼 수 있음, 신청 또는 수락이 된다면 리스트에 출력 X
+
 
     // 현재 로그인 한 사용자가 게시물에 신청된 상태 확인 api
-    PendingListResponse getMyPendingStatus(Long memberId, Long accompanyPostId);
+    PendingResponse getMyPendingStatus(Long memberId, Long accompanyPostId);
 
     // 사용자가 해당 게시물에 신청하는 api
-    PendingListResponse accompanyPending(Long memberId, Long accompanyPostId);
+    PendingResponse accompanyPending(Long memberId, Long accompanyPostId);
+
+    // TODO 신청자가 해당 신청을 취소하는 api
+    // - 신청자가 해당 신청을 취소한다면 다시 신청 가능
+    PendingResponse cancelPending(Long memberId, Long accompanyPostId);
+
+    // TODO 게시물 작성자가 해당 신청을 수락하는 api
+    // - 신청을 수락한다면(수락된다면) 채팅방 참여 멤버로 등록
+    PendingResponse acceptPending(Long memberId, Long accompanyPostId);
+
+    // TODO 게시물 작성자가 해당 신청을 거절하는 api
+    // - 신청자가 거절 당한다면 해당 게시물에 다시 신청 못 함.
+    PendingResponse rejectPending(Long memberId, Long accompanyPostId);
+
+
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
@@ -1,9 +1,13 @@
 package connectripbe.connectrip_be.pending_list.service.impl;
 
+import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
+import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
+import connectripbe.connectrip_be.chat.repository.ChatRoomRepository;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
+import connectripbe.connectrip_be.pending_list.dto.PendingListResponse;
 import connectripbe.connectrip_be.pending_list.dto.PendingResponse;
 import connectripbe.connectrip_be.pending_list.entity.PendingListEntity;
 import connectripbe.connectrip_be.pending_list.entity.type.PendingStatus;
@@ -11,6 +15,7 @@ import connectripbe.connectrip_be.pending_list.repository.PendingListRepository;
 import connectripbe.connectrip_be.pending_list.service.PendingListService;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
 import connectripbe.connectrip_be.post.repository.AccompanyPostRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,10 +23,42 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PendingListServiceImpl implements PendingListService {
 
-    // 의존성 주입된 레포지토리들
+
     private final PendingListRepository pendingListRepository;
     private final MemberJpaRepository memberJpaRepository;
     private final AccompanyPostRepository accompanyPostRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+
+    /**
+     * 게시물 작성자 또는 방장이 해당 게시물에 신청한 사용자들의 리스트를 조회
+     *
+     * @param memberId        조회할 사용자의 ID
+     * @param accompanyPostId 조회할 게시물의 ID
+     * @return List<PendingListResponse> 게시물에 신청한 사용자들의 리스트
+     */
+    @Override
+    public List<PendingListResponse> getPendingList(Long memberId, Long accompanyPostId) {
+        MemberEntity member = getMember(memberId);
+
+        ChatRoomEntity chatRoom = chatRoomRepository.findByAccompanyPost_Id(accompanyPostId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.CHATROOM_NOT_FOUND));
+
+        //현재 사용자가 해당 채팅방 방장(리더)인지 확인
+        if (!chatRoom.getCurrentLeader().getMember().equals(member)) {
+            throw new GlobalException(ErrorCode.NOT_CHATROOM_LEADER);
+        }
+
+        // 채팅방에 속한 멤버들의 리스트 조회
+        List<PendingListEntity> pendingList = pendingListRepository.findByAccompanyPost(chatRoom.getAccompanyPost());
+
+        // 상태가 PENDING 인 신청자들의 리스트를 반환
+        return pendingList.stream()
+                .filter(pending -> pending.getStatus().equals(PendingStatus.PENDING))
+                .map(PendingListResponse::fromEntity)
+                .toList();
+    }
 
     /**
      * 현재 로그인한 사용자가 특정 동행 게시물에 대해 신청한 상태를 확인

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
@@ -4,7 +4,7 @@ import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
-import connectripbe.connectrip_be.pending_list.dto.PendingListResponse;
+import connectripbe.connectrip_be.pending_list.dto.PendingResponse;
 import connectripbe.connectrip_be.pending_list.entity.PendingListEntity;
 import connectripbe.connectrip_be.pending_list.entity.type.PendingStatus;
 import connectripbe.connectrip_be.pending_list.repository.PendingListRepository;
@@ -28,11 +28,11 @@ public class PendingListServiceImpl implements PendingListService {
      *
      * @param accompanyPostId 조회할 게시물의 ID
      * @param memberId        현재 로그인한 사용자의 ID
-     * @return PendingListResponse 사용자의 신청 상태를 반환하는 객체
+     * @return PendingResponse 사용자의 신청 상태를 반환하는 객체
      * @throws GlobalException 사용자의 신청 상태를 찾을 수 없는 경우 예외 발생
      */
     @Override
-    public PendingListResponse getMyPendingStatus(Long memberId, Long accompanyPostId) {
+    public PendingResponse getMyPendingStatus(Long memberId, Long accompanyPostId) {
         try {
             // 게시물 ID로 AccompanyPostEntity 조회
             AccompanyPostEntity accompanyPost = getAccompanyPost(accompanyPostId);
@@ -51,17 +51,17 @@ public class PendingListServiceImpl implements PendingListService {
                     .orElseThrow(() -> new GlobalException(ErrorCode.PENDING_NOT_FOUND));
 
             // 조회된 신청 상태를 반환
-            return PendingListResponse.builder()
+            return PendingResponse.builder()
                     .status(pendingStatus.getStatus().toString())
                     .build();
 
         } catch (GlobalException e) {
             if (ErrorCode.PENDING_NOT_FOUND.equals(e.getErrorCode())) {
-                return PendingListResponse.builder()
+                return PendingResponse.builder()
                         .status("DEFAULT")
                         .build();
             } else if (ErrorCode.WRITE_YOURSELF.equals(e.getErrorCode())) {
-                return PendingListResponse.builder()
+                return PendingResponse.builder()
                         .status("NONE")
                         .build();
             } else {
@@ -75,11 +75,11 @@ public class PendingListServiceImpl implements PendingListService {
      *
      * @param accompanyPostId 신청할 게시물의 ID
      * @param memberId        현재 로그인한 사용자의 아이디
-     * @return PendingListResponse 생성된 신청 상태를 반환하는 객체
+     * @return PendingResponse 생성된 신청 상태를 반환하는 객체
      * @throws GlobalException 사용자가 존재하지 않거나 게시물을 찾을 수 없는 경우 예외 발생
      */
     @Override
-    public PendingListResponse accompanyPending(Long memberId, Long accompanyPostId) {
+    public PendingResponse accompanyPending(Long memberId, Long accompanyPostId) {
         // 이메일로 MemberEntity 조회
         MemberEntity member = getMember(memberId);
         // 게시물 ID로 AccompanyPostEntity 조회
@@ -106,9 +106,24 @@ public class PendingListServiceImpl implements PendingListService {
         PendingListEntity saved = pendingListRepository.save(pendingListEntity);
 
         // 저장된 신청 상태를 반환
-        return PendingListResponse.builder()
+        return PendingResponse.builder()
                 .status(saved.getStatus().toString())
                 .build();
+    }
+
+    @Override
+    public PendingResponse cancelPending(Long memberId, Long accompanyPostId) {
+        return null;
+    }
+
+    @Override
+    public PendingResponse acceptPending(Long memberId, Long accompanyPostId) {
+        return null;
+    }
+
+    @Override
+    public PendingResponse rejectPending(Long memberId, Long accompanyPostId) {
+        return null;
     }
 
     /**

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
@@ -1,7 +1,6 @@
 package connectripbe.connectrip_be.pending_list.service.impl;
 
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
-import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
 import connectripbe.connectrip_be.chat.repository.ChatRoomRepository;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
@@ -28,7 +27,6 @@ public class PendingListServiceImpl implements PendingListService {
     private final MemberJpaRepository memberJpaRepository;
     private final AccompanyPostRepository accompanyPostRepository;
     private final ChatRoomRepository chatRoomRepository;
-    private final ChatRoomMemberRepository chatRoomMemberRepository;
 
 
     /**

--- a/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
@@ -1,7 +1,9 @@
 package connectripbe.connectrip_be.pending_list.web;
 
+import connectripbe.connectrip_be.pending_list.dto.PendingListResponse;
 import connectripbe.connectrip_be.pending_list.dto.PendingResponse;
 import connectripbe.connectrip_be.pending_list.service.PendingListService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,5 +35,14 @@ public class PendingListController {
             @PathVariable Long id
     ) {
         return ResponseEntity.ok(pendingListService.accompanyPending(memberId, id));
+    }
+
+    // 신청 내역 리스트 출력
+    @GetMapping("/list")
+    public ResponseEntity<List<PendingListResponse>> getPendingList(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(pendingListService.getPendingList(memberId, id));
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
@@ -1,6 +1,6 @@
 package connectripbe.connectrip_be.pending_list.web;
 
-import connectripbe.connectrip_be.pending_list.dto.PendingListResponse;
+import connectripbe.connectrip_be.pending_list.dto.PendingResponse;
 import connectripbe.connectrip_be.pending_list.service.PendingListService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +20,7 @@ public class PendingListController {
 
     // 동행 신청 상태 조회
     @GetMapping
-    public ResponseEntity<PendingListResponse> getMyPendingStatus(
+    public ResponseEntity<PendingResponse> getMyPendingStatus(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long id) {
         return ResponseEntity.ok(pendingListService.getMyPendingStatus(memberId, id));
@@ -28,10 +28,10 @@ public class PendingListController {
 
     // 동행 신청
     @PostMapping
-    public ResponseEntity<PendingListResponse> accompanyPending(
+    public ResponseEntity<PendingResponse> accompanyPending(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long id
-            ) {
+    ) {
         return ResponseEntity.ok(pendingListService.accompanyPending(memberId, id));
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
+++ b/src/main/java/connectripbe/connectrip_be/post/web/AccompanyPostController.java
@@ -1,16 +1,26 @@
 package connectripbe.connectrip_be.post.web;
 
 import connectripbe.connectrip_be.global.dto.GlobalResponse;
-import connectripbe.connectrip_be.post.dto.*;
+import connectripbe.connectrip_be.post.dto.AccompanyPostListResponse;
+import connectripbe.connectrip_be.post.dto.AccompanyPostResponse;
+import connectripbe.connectrip_be.post.dto.CheckDuplicatedCustomUrlDto;
+import connectripbe.connectrip_be.post.dto.CreateAccompanyPostRequest;
+import connectripbe.connectrip_be.post.dto.UpdateAccompanyPostRequest;
 import connectripbe.connectrip_be.post.exception.DuplicatedCustomUrlException;
 import connectripbe.connectrip_be.post.service.AccompanyPostService;
-
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/accompany/posts")
@@ -20,37 +30,28 @@ public class AccompanyPostController {
     private final AccompanyPostService accompanyPostService;
 
     @PostMapping
-    public ResponseEntity<GlobalResponse<?>> createAccompanyPost(
-            @AuthenticationPrincipal Long memberId,
-            @RequestBody CreateAccompanyPostRequest request
-    ) {
+    public ResponseEntity<GlobalResponse<?>> createAccompanyPost(@AuthenticationPrincipal Long memberId,
+                                                                 @RequestBody CreateAccompanyPostRequest request) {
         accompanyPostService.createAccompanyPost(memberId, request);
         return ResponseEntity.ok(new GlobalResponse<>("SUCCESS", null));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<AccompanyPostResponse> readAccompanyPost(
-            @PathVariable Long id
-    ) {
+    public ResponseEntity<AccompanyPostResponse> readAccompanyPost(@PathVariable Long id) {
         AccompanyPostResponse response = accompanyPostService.readAccompanyPost(id);
         return ResponseEntity.ok(response);  // 데이터 반환
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<AccompanyPostResponse> updateAccompanyPost(
-            @AuthenticationPrincipal Long memberId,
-            @PathVariable Long id,
-            @RequestBody UpdateAccompanyPostRequest request
-    ) {
+    public ResponseEntity<AccompanyPostResponse> updateAccompanyPost(@AuthenticationPrincipal Long memberId,
+                                                                     @PathVariable Long id,
+                                                                     @RequestBody UpdateAccompanyPostRequest request) {
         AccompanyPostResponse response = accompanyPostService.updateAccompanyPost(memberId, id, request);
         return ResponseEntity.ok(response);  // 수정된 데이터 반환
     }
 
     @PostMapping("/{id}")
-    public ResponseEntity<Void> deleteAccompanyPost(
-            @AuthenticationPrincipal Long memberId,
-            @PathVariable Long id
-    ) {
+    public ResponseEntity<Void> deleteAccompanyPost(@AuthenticationPrincipal Long memberId, @PathVariable Long id) {
         accompanyPostService.deleteAccompanyPost(memberId, id);
         return ResponseEntity.ok().build();  // 삭제는 빈 응답
     }
@@ -62,31 +63,22 @@ public class AccompanyPostController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<List<AccompanyPostListResponse>> searchByQuery(
-            @RequestParam String query
-    ) {
+    public ResponseEntity<List<AccompanyPostListResponse>> searchByQuery(@RequestParam String query) {
         return ResponseEntity.ok(accompanyPostService.searchByQuery(query));
     }
 
     // fixme-noah: 추후 다르 중복 확인 메서드 모두 이름 수정, 혼동 있음
     @GetMapping("/check-custom-url")
     public ResponseEntity<GlobalResponse<CheckDuplicatedCustomUrlDto>> checkDuplicatedCustomUrl(
-            @RequestParam String customUrl
-    ) {
+            @RequestParam String customUrl) {
         boolean result = accompanyPostService.checkDuplicatedCustomUrl(customUrl);
 
-        return ResponseEntity.ok(
-                new GlobalResponse<>(
-                        result ? "DUPLICATED_CUSTOM_URL" : "SUCCESS",
-                        new CheckDuplicatedCustomUrlDto(result)
-                )
-        );
+        return ResponseEntity.ok(new GlobalResponse<>(result ? "DUPLICATED_CUSTOM_URL" : "SUCCESS",
+                new CheckDuplicatedCustomUrlDto(result)));
     }
 
     @ExceptionHandler(DuplicatedCustomUrlException.class)
-    public ResponseEntity<GlobalResponse<CheckDuplicatedCustomUrlDto>> handleException(
-            Exception e
-    ) {
+    public ResponseEntity<GlobalResponse<CheckDuplicatedCustomUrlDto>> handleException(Exception e) {
         return ResponseEntity.status(409).body(new GlobalResponse<>("DUPLICATED_CUSTOM_URL", null));
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,13 +4,15 @@ spring:
     url: ${LOCAL_DATABASE_URL}
     username: ${LOCAL_DATABASE_USERNAME}
     password: ${LOCAL_DATABASE_PASSWORD}
+
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
     show-sql: true
+
   jwt:
     secret-key: ${LOCAL_JWT_SECRET_KEY}
 

--- a/src/test/java/connectripbe/connectrip_be/accompany_member/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/connectripbe/connectrip_be/accompany_member/service/impl/ChatRoomServiceImplTest.java
@@ -41,7 +41,7 @@ public class ChatRoomServiceImplTest {
             AccompanyPostEntity accompanyPost = AccompanyPostEntity.builder()
                     .id(1L)
                     .title("Test Title")
-                    .accompanyArea(AccompanyArea.SEOUL)
+                    .accompanyArea(AccompanyArea.SEOUL.toString())
                     .startDate(LocalDateTime.now())
                     .endDate(LocalDateTime.now().plusDays(5))
                     .build();
@@ -58,7 +58,7 @@ public class ChatRoomServiceImplTest {
             // chatRoomMemberRepository가 특정 이메일에 대한 데이터를 반환하도록 설정
             when(chatRoomMemberRepository.findByMember_Email(email)).thenReturn(List.of(memberEntity));
 
-            List<ChatRoomListResponse> result = chatRoomService.getChatRoomList(email);
+            List<ChatRoomListResponse> result = chatRoomService.getChatRoomList(1L);
 
             assertEquals(1, result.size());  // 반환된 리스트의 크기 검증
             assertEquals(1L, result.get(0).chatRoomId());  // chatRoomId 검증
@@ -73,7 +73,7 @@ public class ChatRoomServiceImplTest {
             String email = "test@example.com";
             when(chatRoomMemberRepository.findByMember_Email(email)).thenReturn(List.of());
 
-            List<ChatRoomListResponse> result = chatRoomService.getChatRoomList(email);
+            List<ChatRoomListResponse> result = chatRoomService.getChatRoomList(1L);
 
             assertEquals(0, result.size());
       }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요

- 채팅방 방장이 신청자 목록을 조회할 수 있도록 하는 기능을 추가하여, 방장이 동행 신청을 관리할 수 있게 합니다.
-  #96 

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

1. **신청자 목록 조회 기능 추가**:
   - 채팅방 방장이 신청자 목록을 조회할 수 있는 기능을 추가했습니다.
   - 방장은 해당 채팅방에 대한 신청자들의 리스트를 조회할 수 있으며, 신청 상태가 `PENDING`인 사용자만 조회됩니다.

2. **`PendingListResponse` 리팩토링**:
   - 기존의 `PendingListResponse`를 `PendingResponse`로 이름을 변경하고, 필요한 데이터를 재구성했습니다.
   - 새로운 데이터 구조에 따라 `PendingListResponse`는 신청자의 기본 정보와 프로필 이미지를 포함하도록 변경되었습니다.

3. **서비스 및 컨트롤러 업데이트**:
   - `PendingListService` 및 `PendingListController`에서 관련 메서드를 수정하여 새롭게 리팩토링된 `PendingResponse` 객체를 반환하도록 했습니다.
   - 신청자 리스트 조회와 관련된 API를 추가하고, 기존의 동행 신청 관련 API도 리팩토링된 응답 객체를 사용하도록 변경했습니다.

4. **오류 코드 추가**:
   - 방장이 아닌 사용자가 신청자 목록에 접근할 경우 `NOT_CHATROOM_LEADER` 오류 코드를 반환하도록 처리했습니다.
   - 이 외에도 필요한 오류 코드가 추가되었습니다.

5. **테스트 코드 수정**:
   - 새로운 기능 및 리팩토링에 맞춰 테스트 코드를 업데이트했습니다.
   - 채팅방 목록을 조회할 때 새로운 `memberId` 기준으로 작동하도록 테스트 로직을 수정했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 ‘없음’ 이라고 기재해 주세요

- AWS S3 서비스의 일부 메서드가 리팩토링되어 예외 처리 및 로그 메시지가 추가되었습니다.
- 일부 잘못된 주석과 코드 스타일이 수정되었습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드 작성
- [x] API 테스트 진행
