### PR TITLE
feat: 동행 신청 수락 및 거절 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+
     /**
      * 400 Bad Request
      */
@@ -45,8 +46,13 @@ public enum ErrorCode {
     NOT_FOUND_ACCOMPANY_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "동행 상태를 찾을 수 없습니다."),
     ALREADY_FINISHED_ACCOMPANY_STATUS_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 종료된 동행압니다."),
 
+    // Pending List, 신청 목록
+    PENDING_ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "이미 수락된 신청입니다."),
+    PENDING_ALREADY_REJECTED(HttpStatus.BAD_REQUEST, "이미 거절된 신청입니다."),
+
     // Meeting error
     DUPLICATE_MEETING(HttpStatus.BAD_REQUEST, "이미 모임에 참여하셨습니다."),
+
 
     // ChatRoom error
     ALREADY_JOINED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 참여한 채팅방입니다."),

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
@@ -17,17 +17,15 @@ public interface PendingListService {
     // 사용자가 해당 게시물에 신청하는 api
     PendingResponse accompanyPending(Long memberId, Long accompanyPostId);
 
-    // TODO 신청자가 해당 신청을 취소하는 api
-    // - 신청자가 해당 신청을 취소한다면 다시 신청 가능
-    PendingResponse cancelPending(Long memberId, Long accompanyPostId);
-
-    // TODO 게시물 작성자가 해당 신청을 수락하는 api
     // - 신청을 수락한다면(수락된다면) 채팅방 참여 멤버로 등록
     PendingResponse acceptPending(Long memberId, Long accompanyPostId);
 
-    // TODO 게시물 작성자가 해당 신청을 거절하는 api
     // - 신청자가 거절 당한다면 해당 게시물에 다시 신청 못 함.
     PendingResponse rejectPending(Long memberId, Long accompanyPostId);
+
+    // TODO 신청자가 해당 신청을 취소하는 api
+    // - 신청자가 해당 신청을 취소한다면 다시 신청 가능
+    PendingResponse cancelPending(Long memberId, Long accompanyPostId);
 
 
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
@@ -45,4 +45,22 @@ public class PendingListController {
     ) {
         return ResponseEntity.ok(pendingListService.getPendingList(memberId, id));
     }
+
+    // 동행 신청 수락
+    @PostMapping("/accept")
+    public ResponseEntity<PendingResponse> acceptPending(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(pendingListService.acceptPending(memberId, id));
+    }
+
+    // 동행 신청 거절
+    @PostMapping("/reject")
+    public ResponseEntity<PendingResponse> rejectPending(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(pendingListService.rejectPending(memberId, id));
+    }
 }


### PR DESCRIPTION

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요

- 사용자가 동행 신청을 했을 때, 게시물 작성자나 채팅방 방장이 해당 신청을 수락하거나 거절할 수 있도록 기능을 추가

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

1. **동행 신청 수락 기능 추가**:
   - 게시물 작성자나 채팅방 방장이 동행 신청을 수락할 수 있습니다.
   - 신청이 수락되면 신청 상태가 `ACCEPTED`로 변경되고, 해당 사용자가 자동으로 채팅방에 추가됩니다.
   - 수락된 신청에 대해서는 중복 수락을 방지하기 위해 예외 처리가 추가되었습니다.

2. **동행 신청 거절 기능 추가**:
   - 게시물 작성자나 채팅방 방장이 동행 신청을 거절할 수 있습니다.
   - 신청이 거절되면 신청 상태가 `REJECTED`로 변경되며, 해당 사용자는 다시 신청할 수 없습니다.
   - 거절된 신청에 대해서는 중복 거절을 방지하기 위해 예외 처리가 추가되었습니다.

3. **오류 코드 추가**:
   - `PENDING_ALREADY_ACCEPTED`: 이미 수락된 신청을 다시 수락하려 할 때 발생하는 오류 코드가 추가되었습니다.
   - `PENDING_ALREADY_REJECTED`: 이미 거절된 신청을 다시 거절하려 할 때 발생하는 오류 코드가 추가되었습니다.

4. **서비스 및 컨트롤러 업데이트**:
   - `PendingListService`에 동행 신청 수락 및 거절 기능이 추가되었습니다.
   - `PendingListController`에 해당 기능을 호출할 수 있는 API가 추가되었습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 ‘없음’ 이라고 기재해 주세요

- 기존 코드의 일부 주석과 코드 스타일이 수정되었습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
 - [ ] 테스트 코드 작성
-  [ ] API 테스트 진행

#96 