### PR TITLE
feat: 사용자가 동행 신청을 취소하는 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/dto/PendingRequest.java
@@ -1,9 +1,0 @@
-package connectripbe.connectrip_be.pending_list.dto;
-
-import lombok.Builder;
-
-@Builder
-public record PendingRequest(
-) {
-
-}

--- a/src/main/java/connectripbe/connectrip_be/pending_list/entity/type/PendingStatus.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/entity/type/PendingStatus.java
@@ -10,8 +10,8 @@ public enum PendingStatus {
     PENDING("대기중"),
     ACCEPTED("수락"),
     REJECTED("거절"),
-    EXIT_ROOM("나감")
-    ;
+    EXIT_ROOM("나감"),
+    DEFAULT("기본");
 
     private final String message;
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/PendingListService.java
@@ -17,14 +17,13 @@ public interface PendingListService {
     // 사용자가 해당 게시물에 신청하는 api
     PendingResponse accompanyPending(Long memberId, Long accompanyPostId);
 
-    // - 신청을 수락한다면(수락된다면) 채팅방 참여 멤버로 등록
+    // 신청을 수락한다면(수락된다면) 채팅방 참여 멤버로 등록
     PendingResponse acceptPending(Long memberId, Long accompanyPostId);
 
-    // - 신청자가 거절 당한다면 해당 게시물에 다시 신청 못 함.
+    // 신청자가 거절 당한다면 해당 게시물에 다시 신청 못 함.
     PendingResponse rejectPending(Long memberId, Long accompanyPostId);
 
-    // TODO 신청자가 해당 신청을 취소하는 api
-    // - 신청자가 해당 신청을 취소한다면 다시 신청 가능
+    //  신청자가 해당 신청을 취소한다면 다시 신청 가능
     PendingResponse cancelPending(Long memberId, Long accompanyPostId);
 
 

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
@@ -211,7 +211,7 @@ public class PendingListServiceImpl implements PendingListService {
     /**
      * 사용자의 동행 신청을 거절합니다.
      * <p>
-     * - 신청 상태를 REJECTED로 변경합니다.
+     * 신청 상태를 REJECTED로 변경합니다.
      *
      * @param memberId        거절할 사용자의 ID
      * @param accompanyPostId 신청한 게시물의 ID
@@ -238,7 +238,15 @@ public class PendingListServiceImpl implements PendingListService {
                 .build();
     }
 
-    //  신청자가 해당 신청을 취소한다면 다시 신청 가능
+
+    /**
+     * 사용자가 자신이 신청한 동행 신청을 취소 . 사용자가 현재 PENDING 상태인 동행 신청을 취소하고, 상태를 DEFAULT 로 변경. 상태가 PENDING 이 아닌 경우, 예외를 발생.
+     *
+     * @param memberId        신청을 취소할 사용자의 ID
+     * @param accompanyPostId 신청을 취소할 게시물의 ID
+     * @return PendingResponse 신청 취소 후의 상태를 반환하는 객체 (DEFAULT 상태)
+     * @throws GlobalException 신청 상태를 찾을 수 없거나, 상태가 PENDING 이 아닌 경우 예외 발생
+     */
     @Override
     public PendingResponse cancelPending(Long memberId, Long accompanyPostId) {
         MemberEntity member = getMember(memberId);
@@ -259,6 +267,7 @@ public class PendingListServiceImpl implements PendingListService {
                 .status(pending.getStatus().toString())
                 .build();
     }
+
 
     /**
      * 이메일을 통해 MemberEntity 를 조회합니다.

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
@@ -104,13 +104,13 @@ public class PendingListServiceImpl implements PendingListService {
                         .status("NONE")
                         .build();
             } else {
-                return null;
+                throw e;
             }
         }
     }
 
     /**
-     * 현재 로그인한 사용자가 특정 동행 게시물에 대해 새로운 동행 신청을 생성.
+     * 사용자가 동행 게시물에 신청합니다.
      *
      * @param accompanyPostId 신청할 게시물의 ID
      * @param memberId        현재 로그인한 사용자의 아이디
@@ -124,37 +124,58 @@ public class PendingListServiceImpl implements PendingListService {
         // 게시물 ID로 AccompanyPostEntity 조회
         AccompanyPostEntity accompanyPost = getAccompanyPost(accompanyPostId);
 
-        // 게시물 작성자와 현재 로그인한 사용자가 같은지 확인
-        if (accompanyPost.getMemberEntity().getId().equals(memberId)) {
-            throw new GlobalException(ErrorCode.WRITE_YOURSELF);
+        try {
+            // 게시물 작성자와 현재 로그인한 사용자가 같은지 확인
+            if (accompanyPost.getMemberEntity().getId().equals(memberId)) {
+                throw new GlobalException(ErrorCode.WRITE_YOURSELF);
+            }
+
+            // 이미 신청한 사용자인지 확인
+            if (pendingListRepository.existsByMemberAndAccompanyPost(member, accompanyPost)) {
+                throw new GlobalException(ErrorCode.PENDING_ALREADY_EXISTS);
+            }
+
+            // 새로운 PendingListEntity 생성
+            PendingListEntity pendingListEntity = PendingListEntity.builder()
+                    .member(member)
+                    .accompanyPost(accompanyPost)
+                    .status(PendingStatus.PENDING)
+                    .build();
+
+            // 생성된 엔티티를 저장
+            PendingListEntity saved = pendingListRepository.save(pendingListEntity);
+
+            // 저장된 신청 상태를 반환
+            return PendingResponse.builder()
+                    .status(saved.getStatus().toString())
+                    .build();
+
+        } catch (GlobalException e) {
+            if (ErrorCode.PENDING_ALREADY_EXISTS.equals(e.getErrorCode())) {
+                // 이미 존재하는 신청 상태를 조회
+                PendingListEntity existingPending = pendingListRepository.findByAccompanyPostAndMember(accompanyPost,
+                                member)
+                        .orElseThrow(() -> new GlobalException(ErrorCode.PENDING_NOT_FOUND));
+
+                // 상태가 DEFAULT라면 PENDING으로 업데이트
+                if (existingPending.getStatus().equals(PendingStatus.DEFAULT)) {
+                    existingPending.updateStatus(PendingStatus.PENDING);
+                    pendingListRepository.save(existingPending);
+                }
+
+                // 현재 상태를 반환
+                return PendingResponse.builder()
+                        .status(existingPending.getStatus().toString())
+                        .build();
+            } else {
+                throw e;
+            }
         }
-
-        // 이미 신청한 사용자인지 확인
-        if (pendingListRepository.existsByMemberAndAccompanyPost(member, accompanyPost)) {
-            throw new GlobalException(ErrorCode.PENDING_ALREADY_EXISTS);
-        }
-
-        // 새로운 PendingListEntity 생성
-        PendingListEntity pendingListEntity = PendingListEntity.builder()
-                .member(member)
-                .accompanyPost(accompanyPost)
-                .status(PendingStatus.PENDING)
-                .build();
-
-        // 생성된 엔티티를 저장
-        PendingListEntity saved = pendingListRepository.save(pendingListEntity);
-
-        // 저장된 신청 상태를 반환
-        return PendingResponse.builder()
-                .status(saved.getStatus().toString())
-                .build();
     }
 
 
     /**
-     * 사용자의 동행 신청을 수락합니다.
-     * <p>
-     * - 신청 상태를 ACCEPTED로 변경하고, 해당 사용자를 채팅방에 추가합니다.
+     * 사용자의 동행 신청을 수락. - 신청 상태를 ACCEPTE D로 변경하고, 해당 사용자를 채팅방에 추가.
      *
      * @param memberId        수락할 사용자의 ID
      * @param accompanyPostId 신청한 게시물의 ID
@@ -217,10 +238,26 @@ public class PendingListServiceImpl implements PendingListService {
                 .build();
     }
 
+    //  신청자가 해당 신청을 취소한다면 다시 신청 가능
     @Override
     public PendingResponse cancelPending(Long memberId, Long accompanyPostId) {
+        MemberEntity member = getMember(memberId);
+        AccompanyPostEntity accompanyPost = getAccompanyPost(accompanyPostId);
 
-        return null;
+        PendingListEntity pending = pendingListRepository.findByAccompanyPostAndMember(accompanyPost, member)
+                .orElseThrow(() -> new GlobalException(ErrorCode.PENDING_NOT_FOUND));
+
+        // 상태가 PENDING 인 경우에만 취소 가능
+        if (!pending.getStatus().equals(PendingStatus.PENDING)) {
+            throw new GlobalException(ErrorCode.PENDING_NOT_FOUND);
+        }
+
+        pending.updateStatus(PendingStatus.DEFAULT);
+        pendingListRepository.save(pending);
+
+        return PendingResponse.builder()
+                .status(pending.getStatus().toString())
+                .build();
     }
 
     /**

--- a/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
@@ -63,4 +63,13 @@ public class PendingListController {
     ) {
         return ResponseEntity.ok(pendingListService.rejectPending(memberId, id));
     }
+
+    // 사용자가 본인이 신청한 동행 신청 취소
+    @PostMapping("/cancel")
+    public ResponseEntity<PendingResponse> cancelPending(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(pendingListService.cancelPending(memberId, id));
+    }
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
#96 
- 동행 신청 상태 관리를 개선하고, 사용자가 신청을 취소할 수 있는 기능을 추가합니다. 이를 통해 동행 신청 프로세스에서 발생할 수 있는 문제를 방지하고, 사용자의 편의성을 높입니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

1. **동행 신청 상태 관리 개선**:
   - 새로운 신청 상태인 `DEFAULT`가 `PendingStatus`에 추가되었습니다.
   - 기존 신청이 `DEFAULT` 상태인 경우, 신청을 다시 활성화(`PENDING` 상태)할 수 있도록 로직을 추가했습니다.

2. **동행 신청 취소 기능 추가**:
   - 사용자가 본인이 신청한 동행 신청을 취소할 수 있는 기능이 추가되었습니다.
   - 신청 상태가 `PENDING`인 경우에만 취소가 가능하며, 취소 시 신청 상태가 `DEFAULT`로 변경됩니다.

3. **오류 처리 개선**:
   - 신청 상태가 `PENDING`이 아닌 경우 취소가 불가능하며, 이 경우 `PENDING_NOT_FOUND` 오류를 발생시킵니다.
   - 예외 처리 로직이 개선되어, 기존의 예외 상황에 대한 명확한 오류 메시지를 제공하도록 수정되었습니다.

4. **불필요한 파일 제거**:
   - 사용되지 않는 `PendingRequest` 파일이 삭제되었습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 ‘없음’ 이라고 기재해 주세요

- 일부 코드의 예외 처리 방식이 개선되었으며, 주석이 추가 및 수정되었습니다.

### 테스트
- [x] 새로운 상태 관리 로직 및 취소 기능에 대한 단위 테스트를 추가하여 정상 작동을 확인했습니다.
- [x] 기존의 기능이 영향을 받지 않도록 회귀 테스트를 수행했습니다.

이 PR은 동행 신청의 유연한 관리와 취소 기능을 통해 사용자 경험을 개선하며, 더 안정적인 동행 신청 프로세스를 제공합니다.