### PR TITLE
hotfix: 동행 게시글 내용 타입 VARCHAR(255)에서 TEXT로 변경

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
@@ -2,10 +2,22 @@ package connectripbe.connectrip_be.post.entity;
 
 import connectripbe.connectrip_be.global.entity.BaseEntity;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 @Entity
@@ -39,12 +51,14 @@ public class AccompanyPostEntity extends BaseEntity {
     // fixme-noah: urlQrPath 임시 보류
     private String urlQrPath;
 
+    @Lob
     @Column(nullable = false)
     private String content;
 
     // fixme-eric 동행 요청 상태 임시보류
 
-    public AccompanyPostEntity(MemberEntity memberEntity, String title, LocalDateTime startDate, LocalDateTime endDate, String accompanyArea, String customUrl, String urlQrPath, String content) {
+    public AccompanyPostEntity(MemberEntity memberEntity, String title, LocalDateTime startDate, LocalDateTime endDate,
+                               String accompanyArea, String customUrl, String urlQrPath, String content) {
         this.memberEntity = memberEntity;
         this.title = title;
         this.startDate = startDate;
@@ -55,7 +69,8 @@ public class AccompanyPostEntity extends BaseEntity {
         this.content = content;
     }
 
-    public void updateAccompanyPost(String title, LocalDateTime startDate, LocalDateTime endDate, String accompanyArea, String content, String customUrl) {
+    public void updateAccompanyPost(String title, LocalDateTime startDate, LocalDateTime endDate, String accompanyArea,
+                                    String content, String customUrl) {
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -63,6 +78,4 @@ public class AccompanyPostEntity extends BaseEntity {
         this.content = content;
         this.customUrl = customUrl;
     }
-
-
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 동행 게시글 255글자 이상 입력 시 데이터베이스 관련 예외 발생

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 동행 게시글 내용 타입 VARCHAR(255)에서 TEXT로 변경

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 관련 이슈

- #102

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 