### PR TITLE
feat: 채팅방 입장 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomEnterDto.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomEnterDto.java
@@ -1,0 +1,20 @@
+package connectripbe.connectrip_be.chat.dto;
+
+import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
+import lombok.Builder;
+
+@Builder
+public record ChatRoomEnterDto(
+        Long accompanyPostId,
+        Long chatRoomId,
+        Long leaderId
+) {
+
+    public static ChatRoomEnterDto fromEntity(ChatRoomEntity chatRoom) {
+        return ChatRoomEnterDto.builder()
+                .accompanyPostId(chatRoom.getAccompanyPost().getId())
+                .chatRoomId(chatRoom.getId())
+                .leaderId(chatRoom.getCurrentLeader().getMember().getId())
+                .build();
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
@@ -1,16 +1,20 @@
 package connectripbe.connectrip_be.chat.service;
 
+import connectripbe.connectrip_be.chat.dto.ChatRoomEnterDto;
 import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
 import connectripbe.connectrip_be.chat.dto.ChatRoomMemberResponse;
 import java.util.List;
 
 public interface ChatRoomService {
 
-      List<ChatRoomListResponse> getChatRoomList(Long memberId);
+    List<ChatRoomListResponse> getChatRoomList(Long memberId);
 
-      List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId);
+    List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId);
 
-      void createChatRoom(Long postId, Long memberId);
+    void createChatRoom(Long postId, Long memberId);
 
-      void exitChatRoom(Long chatRoomId, Long id);
+    void exitChatRoom(Long chatRoomId, Long id);
+
+    ChatRoomEnterDto enterChatRoom(Long chatRoomId, Long memberId);
+
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
@@ -17,31 +17,40 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChatRoomController {
 
-      private final ChatRoomService chatRoomService;
+    private final ChatRoomService chatRoomService;
 
-      // 채팅방 목록 조회
-      @GetMapping("/list")
-      public ResponseEntity<List<ChatRoomListResponse>> getChatRoomList(
-              @AuthenticationPrincipal Long memberId
-      ) {
-            return ResponseEntity.ok(chatRoomService.getChatRoomList(memberId));
-      }
+    // 채팅방 목록 조회
+    @GetMapping("/list")
+    public ResponseEntity<List<ChatRoomListResponse>> getChatRoomList(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        return ResponseEntity.ok(chatRoomService.getChatRoomList(memberId));
+    }
 
-      // 해당 채팅방 참여자 목록 조회
-      @GetMapping("/{chatRoomId}/members")
-      public ResponseEntity<?> getChatRoomMembers(
-              @PathVariable Long chatRoomId
-      ) {
-            return ResponseEntity.ok(chatRoomService.getChatRoomMembers(chatRoomId));
-      }
+    // 해당 채팅방 참여자 목록 조회
+    @GetMapping("/{chatRoomId}/members")
+    public ResponseEntity<?> getChatRoomMembers(
+            @PathVariable Long chatRoomId
+    ) {
+        return ResponseEntity.ok(chatRoomService.getChatRoomMembers(chatRoomId));
+    }
 
-      // 해당 채팅방 나가기
-      @PostMapping("/{chatRoomId}/exit")
-      public ResponseEntity<?> exitChatRoom(
-              @PathVariable Long chatRoomId,
-              @AuthenticationPrincipal Long memberId
-      ) {
-            chatRoomService.exitChatRoom(chatRoomId, memberId);
-            return ResponseEntity.ok("채팅방 나가기 완료");
-      }
+    // 해당 채팅방 나가기
+    @PostMapping("/{chatRoomId}/exit")
+    public ResponseEntity<?> exitChatRoom(
+            @PathVariable Long chatRoomId,
+            @AuthenticationPrincipal Long memberId
+    ) {
+        chatRoomService.exitChatRoom(chatRoomId, memberId);
+        return ResponseEntity.ok("채팅방 나가기 완료");
+    }
+
+    // 채팅방 입장
+    @GetMapping("/{chatRoomId}/enter")
+    public ResponseEntity<?> enterChatRoom(
+            @PathVariable Long chatRoomId,
+            @AuthenticationPrincipal Long memberId
+    ) {
+        return ResponseEntity.ok(chatRoomService.enterChatRoom(chatRoomId, memberId));
+    }
 }

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
     PENDING_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 신청한 상태입니다."),
     WRITE_YOURSELF(HttpStatus.BAD_REQUEST, "본인이 작성한 글은 신청할 수 없습니다."),
     NOT_CHATROOM_LEADER(HttpStatus.BAD_REQUEST, "채팅방 방장이 아닙니다."),
+
+
     // Member, 사용자
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATE_MEMBER_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
@@ -52,10 +54,9 @@ public enum ErrorCode {
 
     // Meeting error
     DUPLICATE_MEETING(HttpStatus.BAD_REQUEST, "이미 모임에 참여하셨습니다."),
-
-
     // ChatRoom error
     ALREADY_JOINED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 참여한 채팅방입니다."),
+    ALREADY_EXITED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 나간 채팅방입니다."),
     /**
      * 401 Unauthorized
      */

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -52,8 +52,6 @@ public enum ErrorCode {
     PENDING_ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "이미 수락된 신청입니다."),
     PENDING_ALREADY_REJECTED(HttpStatus.BAD_REQUEST, "이미 거절된 신청입니다."),
 
-    // Meeting error
-    DUPLICATE_MEETING(HttpStatus.BAD_REQUEST, "이미 모임에 참여하셨습니다."),
     // ChatRoom error
     ALREADY_JOINED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 참여한 채팅방입니다."),
     ALREADY_EXITED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 나간 채팅방입니다."),

--- a/src/main/java/connectripbe/connectrip_be/global/util/aws/dto/S3ImageDto.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/aws/dto/S3ImageDto.java
@@ -10,8 +10,4 @@ public record S3ImageDto(
         String fileName,
         Long size
 ) {
-
-
-
-
 }


### PR DESCRIPTION
### PR 제목
**feat: 채팅방 입장 기능 추가 및 관련 오류 처리 개선**

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요

- 사용자가 채팅방에 입장할 수 있는 기능을 추가하고, 이미 나간 채팅방에 다시 입장하려는 경우 발생할 수 있는 오류를 방지.

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

1. **채팅방 입장 기능 추가**:
   - 새로운 `ChatRoomEnterDto`를 추가하여 사용자가 채팅방에 입장할 수 있는 API를 구현했습니다.
   - 채팅방 입장 시 필요한 정보(게시물 ID, 채팅방 ID, 리더 ID)를 반환합니다.

2. **오류 처리 개선**:
   - 이미 나간 채팅방에 다시 입장하려는 경우 발생하는 `ALREADY_EXITED_CHAT_ROOM` 오류를 추가하여, 적절한 오류 메시지를 반환하도록 개선했습니다.
   - `ErrorCode`에 `ALREADY_EXITED_CHAT_ROOM` 오류 코드를 추가했습니다.

3. **코드 리팩토링**:
   - 불필요한 파일 및 코드를 정리하여 코드의 가독성과 유지보수성을 높였습니다.
   - `ChatRoomService`와 `ChatRoomServiceImpl`에 입장 로직을 추가하여 서비스 계층에서의 역할을 명확히 했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 ‘없음’ 이라고 기재해 주세요

- 불필요한 `S3ImageDto` 파일 및 코드가 삭제되었습니다.

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트 