### PR TITLE
fix: 동행 신청 관련 API 경로 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
@@ -47,25 +47,27 @@ public class PendingListController {
     }
 
     // 동행 신청 수락
-    @PostMapping("/accept")
+    @PostMapping("/accept/{memberId}")
     public ResponseEntity<PendingResponse> acceptPending(
-            @AuthenticationPrincipal Long memberId,
-            @PathVariable Long id
+            @PathVariable Long id,
+            @PathVariable Long memberId
+
     ) {
         return ResponseEntity.ok(pendingListService.acceptPending(memberId, id));
     }
 
     // 동행 신청 거절
-    @PostMapping("/reject")
+    @PostMapping("/reject/{memberId}")
     public ResponseEntity<PendingResponse> rejectPending(
-            @AuthenticationPrincipal Long memberId,
-            @PathVariable Long id
+            @PathVariable Long id,
+            @PathVariable Long memberId
+
     ) {
         return ResponseEntity.ok(pendingListService.rejectPending(memberId, id));
     }
 
     // 사용자가 본인이 신청한 동행 신청 취소
-    @PostMapping("/cancel")
+    @PostMapping("/cancel/{memberId}")
     public ResponseEntity<PendingResponse> cancelPending(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long id


### PR DESCRIPTION


### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 동행 신청, 거절시 로그인한 사용자 ID로 불러오는 오류

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 동행 신청 수락, 거절, 취소 API의 경로에서 memberId를 PathVariable로 수정했습니다.
- 오류 방지 및 경로 일관성을 위해 변경했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 