### PR TITLE
refactor: 채팅방 응답 DTO 개선 및 게시물 상태 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomEnterDto.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomEnterDto.java
@@ -7,14 +7,18 @@ import lombok.Builder;
 public record ChatRoomEnterDto(
         Long accompanyPostId,
         Long chatRoomId,
-        Long leaderId
+        Long leaderId,
+        String status,
+        boolean isPostDeleted
 ) {
 
-    public static ChatRoomEnterDto fromEntity(ChatRoomEntity chatRoom) {
+    public static ChatRoomEnterDto fromEntity(ChatRoomEntity chatRoom, String status, boolean isPostDeleted) {
         return ChatRoomEnterDto.builder()
                 .accompanyPostId(chatRoom.getAccompanyPost().getId())
                 .chatRoomId(chatRoom.getId())
                 .leaderId(chatRoom.getCurrentLeader().getMember().getId())
+                .status(status)
+                .isPostDeleted(isPostDeleted)
                 .build();
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomMemberResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomMemberResponse.java
@@ -9,17 +9,15 @@ import lombok.Builder;
 public record ChatRoomMemberResponse(
         Long chatRoomId,
         Long memberId,
-        String memberEmail,
         String memberNickname,
         String memberProfileImage,
         String memberChatRoomStatus
 ) {
 
-    public static ChatRoomMemberResponse fromEntity(ChatRoomMemberEntity chatRoomMember){
+    public static ChatRoomMemberResponse fromEntity(ChatRoomMemberEntity chatRoomMember) {
         return ChatRoomMemberResponse.builder()
                 .chatRoomId(chatRoomMember.getChatRoom().getId())
                 .memberId(chatRoomMember.getMember().getId())
-                .memberEmail(chatRoomMember.getMember().getEmail())
                 .memberNickname(chatRoomMember.getMember().getNickname())
                 .memberProfileImage(chatRoomMember.getMember().getProfileImagePath())
                 .memberChatRoomStatus(chatRoomMember.getStatus().toString())


### PR DESCRIPTION

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요

- 사용자가 채팅방에 입장할 때, 해당 게시물의 상태(삭제 여부 포함)를 정확하게 파악할 수 있도록 개선.

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

1. **채팅방 입장 기능 개선**:
   - `ChatRoomEnterDto`에 `status`와 `isPostDeleted` 필드를 추가하여, 사용자가 채팅방에 입장할 때 게시물의 상태와 삭제 여부를 확인할 수 있도록 하였습니다.
   - 채팅방 입장 시, 관련 게시물의 상태 정보를 함께 반환하도록 로직을 수정하였습니다.

2. **게시물 상태 반영**:
   - 채팅방 입장 시 해당 게시물의 상태(진행 중, 종료됨 등)와 삭제 여부를 확인하여, `ChatRoomEnterDto`에 반영합니다.
   - `ChatRoomServiceImpl` 클래스에서 게시물의 상태를 조회하고, 이를 DTO에 포함시켜 반환합니다.

3. **코드 리팩토링**:
   - `ChatRoomEnterDto`와 관련된 코드에서 불필요한 필드를 제거하고, 명확하게 게시물의 상태를 반영하는 필드를 추가하였습니다.
   - `ChatRoomServiceImpl` 클래스에서 관련된 로직을 정리하여 가독성과 유지보수성을 높였습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 ‘없음’ 이라고 기재해 주세요

- 채팅방 멤버 응답 DTO(`ChatRoomMemberResponse`)에서 사용되지 않는 `memberEmail` 필드를 제거하였습니다.

### 테스트
