### PR TITLE
fix: 채팅방 상태 반환 로직 수정 및 불필요한 주석 제거

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatMessage.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatMessage.java
@@ -21,9 +21,6 @@ import org.springframework.data.mongodb.core.mapping.FieldType;
 @Builder
 public class ChatMessage {
 
-    /**
-     * 몽고디비 설정해서 연결 확인 1. application.properties에 몽고디비 설정 추가 2. MognoDBConfig 클래스 생성
-     */
     @Id
     @Field(value = "_id", targetType = FieldType.OBJECT_ID)
     private String id;

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
@@ -193,7 +193,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         // 게시물이 삭제 되었는지
         boolean isPostDeleted = chatRoom.getAccompanyPost().getDeletedAt() != null;
 
-        return ChatRoomEnterDto.fromEntity(chatRoom, status.toString(), isPostDeleted);
+        return ChatRoomEnterDto.fromEntity(chatRoom, status.getAccompanyStatusEnum().toString(), isPostDeleted);
     }
 
     private void pendingListUpdate(ChatRoomMemberEntity chatRoomMember, ChatRoomEntity chatRoom) {

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
@@ -1,7 +1,9 @@
 package connectripbe.connectrip_be.chat.web;
 
+import connectripbe.connectrip_be.chat.dto.ChatRoomEnterDto;
 import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
 import connectripbe.connectrip_be.chat.service.ChatRoomService;
+import connectripbe.connectrip_be.global.dto.GlobalResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -47,10 +49,15 @@ public class ChatRoomController {
 
     // 채팅방 입장
     @GetMapping("/{chatRoomId}/enter")
-    public ResponseEntity<?> enterChatRoom(
+    public ResponseEntity<GlobalResponse<ChatRoomEnterDto>> enterChatRoom(
             @PathVariable Long chatRoomId,
             @AuthenticationPrincipal Long memberId
     ) {
-        return ResponseEntity.ok(chatRoomService.enterChatRoom(chatRoomId, memberId));
+        return
+                ResponseEntity
+                        .ok()
+                        .body(new GlobalResponse<>("SUCCESS", chatRoomService.enterChatRoom(chatRoomId, memberId)));
+
+
     }
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요

- 채팅방 입장 시 반환되는 상태 정보를 정확하게 제공하며, 불필요한 주석을 제거하여 코드의 가독성과 유지보수성을 높입니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

1. **채팅방 상태 반환 로직 수정**:
   - `ChatRoomEnterDto`의 `status` 필드에 올바른 값이 반환되도록 로직을 수정했습니다. 이전에는 잘못된 상태 정보가 반환되는 문제가 있었습니다.
   - `status` 값을 반환할 때, `AccompanyStatusEntity`의 `getAccompanyStatusEnum()`을 사용하여 정확한 상태를 반환하도록 변경했습니다.

2. **불필요한 주석 제거**:
   - `ChatMessage` 클래스에서 MongoDB 설정과 관련된 불필요한 주석을 제거하여 코드의 깔끔함을 유지했습니다.

3. **API 응답 형식 개선**:
   - `ChatRoomController`에서 채팅방 입장 시 응답을 `GlobalResponse<ChatRoomEnterDto>` 형식으로 감싸서 반환하도록 수정했습니다. 이는 일관된 응답 형식을 유지하기 위함입니다.

### 테스트

### 이 PR이 포함된 기타 변경 사항
> 없으면 ‘없음’ 이라고 기재해 주세요

없음.
