### PR TITLE
fix: ChatMessageDto와 ChatMessageResponse 구분 및 member 조회 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageRequest.java
@@ -1,0 +1,11 @@
+package connectripbe.connectrip_be.chat.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ChatMessageRequest(
+        Long chatRoomId,
+        Long senderId,
+        String content
+) {
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
-public record ChatMessageDto(
+public record ChatMessageResponse(
         String id,
         MessageType type,
         Long chatRoomId,
@@ -16,8 +16,8 @@ public record ChatMessageDto(
         String content,
         LocalDateTime createdAt
 ) {
-    public static ChatMessageDto fromEntity(ChatMessage chatMessage) {
-        return ChatMessageDto.builder()
+    public static ChatMessageResponse fromEntity(ChatMessage chatMessage) {
+        return ChatMessageResponse.builder()
                 .id(chatMessage.getId())
                 .type(chatMessage.getType())
                 .chatRoomId(chatMessage.getChatRoomId())

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatMessageService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatMessageService.java
@@ -1,11 +1,12 @@
 package connectripbe.connectrip_be.chat.service;
 
-import connectripbe.connectrip_be.chat.dto.ChatMessageDto;
+import connectripbe.connectrip_be.chat.dto.ChatMessageRequest;
+import connectripbe.connectrip_be.chat.dto.ChatMessageResponse;
 import java.util.List;
 
 public interface ChatMessageService {
 
-    ChatMessageDto saveMessage(ChatMessageDto chatMessage);
+    ChatMessageResponse saveMessage(ChatMessageRequest chatMessage);
 
-    List<ChatMessageDto> getMessages(Long chatRoomId);
+    List<ChatMessageResponse> getMessages(Long chatRoomId);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
@@ -1,6 +1,7 @@
 package connectripbe.connectrip_be.chat.web;
 
-import connectripbe.connectrip_be.chat.dto.ChatMessageDto;
+import connectripbe.connectrip_be.chat.dto.ChatMessageRequest;
+import connectripbe.connectrip_be.chat.dto.ChatMessageResponse;
 import connectripbe.connectrip_be.chat.service.ChatMessageService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,13 +21,13 @@ public class ChatMessageController {
     private final SimpMessagingTemplate simpMessagingTemplate;
 
     @MessageMapping("/chat/message")
-    public void senMessage(@Payload ChatMessageDto chatMessage) {
-        ChatMessageDto savedMessage = chatMessageService.saveMessage(chatMessage);
+    public void senMessage(@Payload ChatMessageRequest chatMessage) {
+        ChatMessageResponse savedMessage = chatMessageService.saveMessage(chatMessage);
         simpMessagingTemplate.convertAndSend("/sub/chat/room/" + savedMessage.chatRoomId(), savedMessage);
     }
 
     @GetMapping("/api/v1/chatRoom/{chatRoomId}/messages")
-    public ResponseEntity<List<ChatMessageDto>> getChatRoomMessages(@PathVariable Long chatRoomId) {
+    public ResponseEntity<List<ChatMessageResponse>> getChatRoomMessages(@PathVariable Long chatRoomId) {
         return ResponseEntity.ok(chatMessageService.getMessages(chatRoomId));
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/web/PendingListController.java
@@ -67,7 +67,7 @@ public class PendingListController {
     }
 
     // 사용자가 본인이 신청한 동행 신청 취소
-    @PostMapping("/cancel/{memberId}")
+    @PostMapping("/cancel")
     public ResponseEntity<PendingResponse> cancelPending(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long id


### PR DESCRIPTION
#105
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요

- `ChatMessageDto`와 `ChatMessageResponse`를 명확히 구분하고, 메시지 전송 시 사용자의 추가적인 정보를 조회할 수 있도록 개선

### ✨ 이 PR에서 핵심적으로 변경된 사항
> 주요 변경 사항을 요약해 적어주세요

1. **`ChatMessageDto`와 `ChatMessageResponse`의 분리**:
   - 기존 `ChatMessageDto` 클래스가 `ChatMessageRequest`와 `ChatMessageResponse`로 분리되었습니다.
   - `ChatMessageRequest`는 클라이언트로부터 요청을 받을 때 사용되며, `ChatMessageResponse`는 메시지 전송 및 조회 시 사용됩니다.

2. **Member 정보 추가 조회**:
   - 메시지 전송 시 `senderId`를 통해 `MemberEntity`를 조회하여 닉네임과 프로필 이미지를 메시지에 포함할 수 있도록 개선했습니다.

3. **컨트롤러와 서비스 로직 수정**:
   - `ChatMessageController`와 `ChatMessageService`가 새로운 `ChatMessageRequest`와 `ChatMessageResponse`를 사용하도록 수정되었습니다.
   - 메시지 전송 및 조회 시 각 데이터 전송 객체(DTO)가 일관되게 사용됩니다.

4. **엔드포인트 수정**:
   - 동행 신청 취소 엔드포인트의 URL이 `/cancel/{memberId}`에서 `/cancel`로 수정되었습니다.

### 테스트


### 이 PR이 포함된 기타 변경 사항
> 없으면 ‘없음’ 이라고 기재해 주세요

없음.

