### PR TITLE
hotfix: 데이터베이스 중 게시글 content 타입 TEXT로 변경, 댓글 content 타입 VARCHAR(256)로 변경

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/comment/entity/AccompanyCommentEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/entity/AccompanyCommentEntity.java
@@ -3,8 +3,21 @@ package connectripbe.connectrip_be.comment.entity;
 import connectripbe.connectrip_be.global.entity.BaseEntity;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "accompany_comment")
@@ -27,7 +40,7 @@ public class AccompanyCommentEntity extends BaseEntity {
     private AccompanyPostEntity accompanyPostEntity;  // 동행 아이디 (외래키)
 
     @Setter
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 256)
     private String content;  // 내용
 
     // 기존 생성자 제거 (빌더 패턴으로 대체됨)

--- a/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -51,8 +50,7 @@ public class AccompanyPostEntity extends BaseEntity {
     // fixme-noah: urlQrPath 임시 보류
     private String urlQrPath;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     // fixme-eric 동행 요청 상태 임시보류


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 게시글 작성 시 255자를 넘어가면 SQL 에러 발생
- 명세와 달리 댓글에 많은 내용을 담을 수 있음

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 게시글 content 타입을 VARCHAR(255)에서 TEXT로 수정
- 댓글 content 타입을 TEXT에서 VARCHAR(256)으로 변경

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트