### PR TITLE
fix: 채팅 메시지 전송 오류 수정 및 WebSocket 설정 개선

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/auth/config/SecurityConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/config/SecurityConfig.java
@@ -41,7 +41,9 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                        authorizationManagerRequestMatcherRegistry.anyRequest().permitAll())
+                        authorizationManagerRequestMatcherRegistry
+                                .requestMatchers("/ws/**").permitAll()
+                                .anyRequest().permitAll())
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> {
                     httpSecurityExceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint);
                     httpSecurityExceptionHandlingConfigurer.accessDeniedHandler(jwtAccessDeniedHandler);
@@ -57,7 +59,10 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:3000",
                 "https://dev.connectrip.travel/",
-                "https://connectrip.travel/"
+                "https://connectrip.travel/",
+                "ws://localhost:3000",  // WebSocket for local development
+                "wss://dev.connectrip.travel/",  // Secure WebSocket for development environment
+                "wss://connectrip.travel/"  // Secure WebSocket for production environment
         ));
         configuration.addAllowedMethod("*");
         configuration.addAllowedHeader("*");

--- a/src/main/java/connectripbe/connectrip_be/chat/config/WebSocketConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/WebSocketConfig.java
@@ -13,18 +13,21 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 클라이언트가 WebSocket에 연결할 수 있는 엔드포인트를 등록.
-        registry.addEndpoint("/ws")  // 클라이언트가 "/ws" 엔드포인트로 WebSocket 연결을 시도할 수 있도록 설정.
+        registry.addEndpoint("/ws/init")  // 클라이언트가 "/ws" 엔드포인트로 WebSocket 연결을 시도할 수 있도록 설정.
                 .setAllowedOrigins("*");  // 모든 도메인에서의 CORS (Cross-Origin) 요청을 허용.
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        // 메시지를 라우팅할 때 사용할 애플리케이션 목적지 프리픽스를 설정합니다.
-        // 클라이언트가 메시지를 보낼 때 "/pub" 프리픽스를 사용.
-        registry.setApplicationDestinationPrefixes("/pub");
 
         // "/sub"로 시작하는 경로를 구독한 클라이언트에게 메시지를 전달.
         // 메시지를 구독하는 목적지 경로의 프리픽스를 "/sub"으로 설정.
         registry.enableSimpleBroker("/sub");
+
+        // 메시지를 라우팅할 때 사용할 애플리케이션 목적지 프리픽스를 설정.
+        // 클라이언트가 메시지를 보낼 때 "/pub" 프리픽스를 사용.
+        registry.setApplicationDestinationPrefixes("/pub");
+
+
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatMessageService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatMessageService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface ChatMessageService {
 
-    ChatMessageResponse saveMessage(ChatMessageRequest chatMessage);
+    ChatMessageResponse saveMessage(ChatMessageRequest chatMessage, Long chatRoomId);
 
     List<ChatMessageResponse> getMessages(Long chatRoomId);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -25,7 +25,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     private final MemberJpaRepository memberJpaRepository;
 
     @Override
-    public ChatMessageResponse saveMessage(ChatMessageRequest request) {
+    public ChatMessageResponse saveMessage(ChatMessageRequest request, Long chatRoomId) {
         // 채팅 수신 유저 정보 조회
         MemberEntity member = memberJpaRepository.findById(request.senderId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
@@ -33,7 +33,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         ChatMessage chatMessage =
                 ChatMessage.builder()
                         .type(MessageType.TALK)
-                        .chatRoomId(request.chatRoomId())
+                        .chatRoomId(chatRoomId)
                         .senderId(request.senderId())
                         .senderNickname(member.getNickname())
                         .senderProfileImage(member.getProfileImagePath())

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
@@ -6,6 +6,7 @@ import connectripbe.connectrip_be.chat.service.ChatMessageService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -20,10 +21,11 @@ public class ChatMessageController {
     private final ChatMessageService chatMessageService;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    @MessageMapping("/chat/message")
-    public void senMessage(@Payload ChatMessageRequest chatMessage) {
-        ChatMessageResponse savedMessage = chatMessageService.saveMessage(chatMessage);
-        simpMessagingTemplate.convertAndSend("/sub/chat/room/" + savedMessage.chatRoomId(), savedMessage);
+    @MessageMapping("/chat/room/{chatRoomId}")
+    public void sendMessage(@Payload ChatMessageRequest chatMessage,
+                            @DestinationVariable("chatRoomId") Long chatRoomId) {
+        ChatMessageResponse savedMessage = chatMessageService.saveMessage(chatMessage, chatRoomId);
+        simpMessagingTemplate.convertAndSend("/sub/chat/room/" + chatRoomId, savedMessage);
     }
 
     @GetMapping("/api/v1/chatRoom/{chatRoomId}/messages")

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     // ChatRoom error
     ALREADY_JOINED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 참여한 채팅방입니다."),
     ALREADY_EXITED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 나간 채팅방입니다."),
+    USER_NOT_IN_CHAT_ROOM(HttpStatus.BAD_REQUEST, "사용자가 채팅방에 참여하지 않았습니다."),
     /**
      * 401 Unauthorized
      */


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제

- 채팅 메시지 전송 시 발생하는 오류 수정
- WebSocket 설정 관련 문제 해결

### ✨ 이 PR에서 핵심적으로 변경된 사항

- WebSocket 엔드포인트를 `/ws/init`으로 변경
- WebSocket CORS 설정에 `ws/wss` 프로토콜 추가
- 보안 설정에서 WebSocket 경로 허용 추가 (`/ws/**`)
- `sendMessage` 메서드에서 `chatRoomId`를 받을 수 있도록 수정
- 사용자가 채팅방에 참여하지 않은 경우를 처리하기 위한 에러 코드 추가 (`USER_NOT_IN_CHAT_ROOM`)

### 핵심 변경 사항 외에 추가적으로 변경된 부분
- 기존의 WebSocket 엔드포인트가 `/ws`에서 `/ws/init`으로 변경되면서 관련된 보안 설정 및 CORS 설정도 함께 업데이트됨.
- `SecurityConfig.java`와 `WebSocketConfig.java`에서 WebSocket 관련 설정이 개선됨.

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트 

---

