### PR TITLE
fix: WebSocket 엔드포인트의 CORS 설정 수정 및 SockJS 지원 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/config/WebSocketConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/WebSocketConfig.java
@@ -14,7 +14,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 클라이언트가 WebSocket에 연결할 수 있는 엔드포인트를 등록.
         registry.addEndpoint("/ws/init")  // 클라이언트가 "/ws" 엔드포인트로 WebSocket 연결을 시도할 수 있도록 설정.
-                .setAllowedOrigins("*");  // 모든 도메인에서의 CORS (Cross-Origin) 요청을 허용.
+                .setAllowedOrigins("http://localhost:3000")  // 허용할 도메인을 설정.
+                .withSockJS();
     }
 
     @Override


### PR DESCRIPTION

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- WebSocket 엔드포인트의 CORS 설정을 모든 도메인 허용에서 특정 도메인("http://localhost:3000") 허용으로 변경했습니다.
- 클라이언트가 SockJS를 사용할 수 있도록 설정을 추가했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 