### PR TITLE
feat: 메시지 플래그 필드 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageRequest.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 public record ChatMessageRequest(
         Long chatRoomId,
         Long senderId,
-        String content
+        String content,
+        Boolean messageFlag
 ) {
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
@@ -14,6 +14,7 @@ public record ChatMessageResponse(
         String senderNickname,
         String senderProfileImage,
         String content,
+        Boolean messageFlag,
         LocalDateTime createdAt
 ) {
     public static ChatMessageResponse fromEntity(ChatMessage chatMessage) {
@@ -25,6 +26,7 @@ public record ChatMessageResponse(
                 .senderNickname(chatMessage.getSenderNickname())
                 .senderProfileImage(chatMessage.getSenderProfileImage())
                 .content(chatMessage.getContent())
+                .messageFlag(chatMessage.isMessageFlag())
                 .createdAt(chatMessage.getCreatedAt())
                 .build();
     }

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatMessage.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatMessage.java
@@ -48,5 +48,8 @@ public class ChatMessage {
     @CreatedDate
     private LocalDateTime createdAt;
 
+    @Field("message_flag")
+    private boolean messageFlag;
+
 
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -30,6 +30,9 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         MemberEntity member = memberJpaRepository.findById(request.senderId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
 
+        // 유저가 보낸 메세지 전송 여부
+        boolean messageFlag = (request.messageFlag() != null) ? request.messageFlag() : true;
+
         ChatMessage chatMessage =
                 ChatMessage.builder()
                         .type(MessageType.TALK)
@@ -38,6 +41,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                         .senderNickname(member.getNickname())
                         .senderProfileImage(member.getProfileImagePath())
                         .content(request.content())
+                        .messageFlag(messageFlag)
                         .build();
 
         ChatMessage saved = chatMessageRepository.save(chatMessage);


### PR DESCRIPTION


### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 메시지 전송 시, 메시지의 플래그 상태를 관리할 수 없던 문제를 해결

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
-ChatMessageRequest, ChatMessageResponse, ChatMessage 엔티티에 messageFlag 필드 추가.
- ChatMessageServiceImpl에서 messageFlag 기본 값을 설정하는 로직 추가. 이 필드는 메시지가 성공적으로 전송되었는지 여부를 나타내는 플래그로 사용됩니다.
- 메시지 전송 시 messageFlag가 명시되지 않았을 경우, 기본값 true로 설정.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 