### PR TITLE
fix: 첫 로그인 시 바로 DB에 저장되지 않게끔 수정하고, temp token을 통해 차후 회원가입을 진행할 수 있도록 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/auth/jwt/dto/MemberEmailAndProfileImagePathDto.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/jwt/dto/MemberEmailAndProfileImagePathDto.java
@@ -1,0 +1,7 @@
+package connectripbe.connectrip_be.auth.jwt.dto;
+
+public record MemberEmailAndProfileImagePathDto(
+        String memberEmail,
+        String memberProfileImagePath
+) {
+}

--- a/src/main/java/connectripbe/connectrip_be/auth/jwt/dto/TokenDto.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/jwt/dto/TokenDto.java
@@ -6,15 +6,20 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+// fixme-noah 2024-09-04 : TokenDto 분리 필요
+
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class TokenDto {
-
     private String refreshToken;
     private int refreshTokenExpirationTime;
     private String accessToken;
     private int accessTokenExpirationTime;
+
+    private boolean isFirstLogin;
+    private String tempToken;
+    private int tempTokenExpirationTime;
 }

--- a/src/main/java/connectripbe/connectrip_be/auth/kakao/service/KakaoService.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/kakao/service/KakaoService.java
@@ -8,8 +8,6 @@ import connectripbe.connectrip_be.auth.service.AuthService;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
-import connectripbe.connectrip_be.member.entity.type.MemberLoginType;
-import connectripbe.connectrip_be.member.entity.type.MemberRoleType;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -53,18 +51,11 @@ public class KakaoService {
             // 카카오로 처음 로그인(회원가입) 하는 경우, 사용자 정보를 반환하여 추가 정보 입력을 유도한다.
 
             if (ErrorCode.NOT_FOUND_MEMBER.equals(e.getErrorCode())) {
-                MemberEntity newMemberEntity = MemberEntity.builder()
-                        .email(userInfo.getKakaoAccount().getEmail())
-                        .profileImagePath(
-                                getProfileImagePath(userInfo.getKakaoAccount().getKakaoProfile()
-                                        .getImagePath()))
-                        .loginType(MemberLoginType.KAKAO)
-                        .roleType(MemberRoleType.USER) // 기본 사용자 권한 설정
-                        .build();
-                memberJpaRepository.save(newMemberEntity);
+                String memberEmail = userInfo.getKakaoAccount().getEmail();
+                String memberProfileImagePath = getProfileImagePath(
+                        userInfo.getKakaoAccount().getKakaoProfile().getImagePath());
 
-                // 토큰 생성 및 반환
-                return authService.generateToken(newMemberEntity.getId());
+                return authService.generateKaKaoTempToken(memberEmail, memberProfileImagePath);
             } else {
                 throw e; // USER_NOT_FOUND 가 아닌 다른 GlobalException 은 그대로 다시 throw.
             }

--- a/src/main/java/connectripbe/connectrip_be/auth/service/AuthService.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/service/AuthService.java
@@ -13,4 +13,6 @@ public interface AuthService {
     TokenDto signIn(SignInDto request);
 
     TokenDto generateToken(long memberId);
+
+    TokenDto generateKaKaoTempToken(String memberEmail, String memberProfileImagePath);
 }

--- a/src/main/java/connectripbe/connectrip_be/auth/service/AuthServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/service/AuthServiceImpl.java
@@ -9,7 +9,6 @@ import connectripbe.connectrip_be.global.exception.type.ErrorCode;
 import connectripbe.connectrip_be.global.util.aws.service.AwsS3Service;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -64,6 +63,7 @@ public class AuthServiceImpl implements AuthService {
         return generateToken(memberEntity.getId());
     }
 
+    // fixme-noah, 2024-09-04: 로직 분리 필요
     @Override
     public TokenDto generateToken(long memberId) {
         String refreshToken = jwtProvider.generateRefreshToken(memberId);
@@ -75,6 +75,17 @@ public class AuthServiceImpl implements AuthService {
                 .refreshTokenExpirationTime(jwtProvider.getRefreshTokenExpirationTime() / 1000)
                 .accessToken(accessToken)
                 .accessTokenExpirationTime(jwtProvider.getAccessTokenExpirationTime() / 1000)
+                .build();
+    }
+
+    @Override
+    public TokenDto generateKaKaoTempToken(String memberEmail, String memberProfileImagePath) {
+        String kakaoTempToken = jwtProvider.generateKakaoTempToken(memberEmail, memberProfileImagePath);
+
+        return TokenDto.builder()
+                .isFirstLogin(true)
+                .tempToken(kakaoTempToken)
+                .tempTokenExpirationTime(jwtProvider.getKakaoTempTokenExpirationTime() / 1000)
                 .build();
     }
 

--- a/src/main/java/connectripbe/connectrip_be/member/service/MemberService.java
+++ b/src/main/java/connectripbe/connectrip_be/member/service/MemberService.java
@@ -15,5 +15,7 @@ public interface MemberService {
     GlobalResponse<MemberHeaderInfoDto> getMemberHeaderInfo(Long id);
 
     // fixme-noah: 추후 달라지면 response 분리
-    GlobalResponse<MemberHeaderInfoDto> getFirstUpdateMemberResponse(Long id, FirstUpdateMemberRequest request);
+    GlobalResponse<MemberHeaderInfoDto> getFirstUpdateMemberResponse(
+            String tempTokenCookie,
+            FirstUpdateMemberRequest request);
 }

--- a/src/main/java/connectripbe/connectrip_be/member/service/MemberServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/member/service/MemberServiceImpl.java
@@ -1,11 +1,17 @@
 package connectripbe.connectrip_be.member.service;
 
+import connectripbe.connectrip_be.auth.jwt.JwtProvider;
+import connectripbe.connectrip_be.auth.jwt.dto.MemberEmailAndProfileImagePathDto;
 import connectripbe.connectrip_be.global.dto.GlobalResponse;
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
 import connectripbe.connectrip_be.member.dto.CheckDuplicateEmailDto;
 import connectripbe.connectrip_be.member.dto.CheckDuplicateNicknameDto;
 import connectripbe.connectrip_be.member.dto.FirstUpdateMemberRequest;
 import connectripbe.connectrip_be.member.dto.MemberHeaderInfoDto;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
+import connectripbe.connectrip_be.member.entity.type.MemberLoginType;
+import connectripbe.connectrip_be.member.entity.type.MemberRoleType;
 import connectripbe.connectrip_be.member.exception.NotFoundMemberException;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberJpaRepository memberJpaRepository;
+    private final JwtProvider jwtProvider;
 
     @Transactional(readOnly = true)
     @Override
@@ -26,7 +33,8 @@ public class MemberServiceImpl implements MemberService {
     ) {
         boolean existsByEmail = memberJpaRepository.existsByEmail(email);
 
-        return new GlobalResponse<>(existsByEmail ? "DUPLICATED_EMAIL" : "SUCCESS", new CheckDuplicateEmailDto(existsByEmail));
+        return new GlobalResponse<>(existsByEmail ? "DUPLICATED_EMAIL" : "SUCCESS",
+                new CheckDuplicateEmailDto(existsByEmail));
     }
 
     @Transactional(readOnly = true)
@@ -36,7 +44,8 @@ public class MemberServiceImpl implements MemberService {
     ) {
         boolean existsByNickname = memberJpaRepository.existsByNickname(nickname);
 
-        return new GlobalResponse<>(existsByNickname ? "DUPLICATED_NICKNAME" : "SUCCESS", new CheckDuplicateNicknameDto(existsByNickname));
+        return new GlobalResponse<>(existsByNickname ? "DUPLICATED_NICKNAME" : "SUCCESS",
+                new CheckDuplicateNicknameDto(existsByNickname));
     }
 
     /**
@@ -59,25 +68,36 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     @Override
     public GlobalResponse<MemberHeaderInfoDto> getFirstUpdateMemberResponse(
-            Long id,
+            String tempTokenCookie,
             FirstUpdateMemberRequest request
     ) {
-        MemberEntity memberEntity = memberJpaRepository.findById(id)
-                .orElseThrow(NotFoundMemberException::new);
+        if (!jwtProvider.validateToken(tempTokenCookie)) {
+            throw new GlobalException(ErrorCode.INVALID_TOKEN);
+        }
 
         // fixme-noah: 추후 글로벌 response가 정해지면 exception handler로 변경
         if (memberJpaRepository.existsByNickname(request.nickname())) {
             return new GlobalResponse<>("DUPLICATED_NICKNAME", null);
         }
 
-        memberEntity.firstUpdate(request.nickname(), request.birthDate(), request.gender());
+        MemberEmailAndProfileImagePathDto memberProfileImagePathDto = jwtProvider.getMemberProfileImagePathDtoFromToken(
+                tempTokenCookie);
+
+        MemberEntity newMemberEntity = MemberEntity.builder()
+                .email(memberProfileImagePathDto.memberEmail())
+                .profileImagePath(memberProfileImagePathDto.memberProfileImagePath())
+                .loginType(MemberLoginType.KAKAO)
+                .roleType(MemberRoleType.USER) // 기본 사용자 권한 설정
+                .build();
+
+        MemberEntity savedMemberEntity = memberJpaRepository.save(newMemberEntity);
 
         return new GlobalResponse<>(
                 "SUCCESS",
                 MemberHeaderInfoDto.builder()
-                        .memberId(memberEntity.getId())
-                        .profileImagePath(memberEntity.getProfileImagePath())
-                        .nickname(memberEntity.getNickname())
+                        .memberId(savedMemberEntity.getId())
+                        .profileImagePath(savedMemberEntity.getProfileImagePath())
+                        .nickname(savedMemberEntity.getNickname())
                         .build());
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/member/web/MemberController.java
+++ b/src/main/java/connectripbe/connectrip_be/member/web/MemberController.java
@@ -9,7 +9,13 @@ import connectripbe.connectrip_be.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -42,11 +48,14 @@ public class MemberController {
     // fixme-noah: 2024-08-21, 엉망 코드
     @PostMapping("/first")
     public ResponseEntity<GlobalResponse<MemberHeaderInfoDto>> firstUpdateMember(
-            @AuthenticationPrincipal Long id,
+            @CookieValue(value = "tempToken") String tempTokenCookie,
             @RequestBody FirstUpdateMemberRequest request
     ) {
-        GlobalResponse<MemberHeaderInfoDto> firstUpdateMemberResponse = memberService.getFirstUpdateMemberResponse(id, request);
+        GlobalResponse<MemberHeaderInfoDto> firstUpdateMemberResponse = memberService.getFirstUpdateMemberResponse(
+                tempTokenCookie,
+                request);
 
-        return ResponseEntity.status(firstUpdateMemberResponse.message().equals("SUCCESS") ? 200 : 409).body(firstUpdateMemberResponse);
+        return ResponseEntity.status(firstUpdateMemberResponse.message().equals("SUCCESS") ? 200 : 409)
+                .body(firstUpdateMemberResponse);
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
@@ -32,7 +32,7 @@ public class AccompanyPostEntity extends BaseEntity {
     private long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member__id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private MemberEntity memberEntity;
 
     @Column(nullable = false)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,6 +21,7 @@ spring:
 
   auth:
     success-redirect-url: ${DEV_KAKAO_SUCCESS_REDIRECT_URL}
+    first-login-redirect-url: ${DEV_KAKAO_FIRST_LOGIN_REDIRECT_URL}
     kakao:
       client-id: ${DEV_KAKAO_CLIENT_ID}
       redirect-uri: ${DEV_KAKAO_REDIRECT_URI}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
@@ -31,6 +31,7 @@ spring:
 
   auth:
     success-redirect-url: ${LOCAL_KAKAO_SUCCESS_REDIRECT_URL}
+    first-login-redirect-url: ${LOCAL_KAKAO_FIRST_LOGIN_REDIRECT_URL}
     kakao:
       client-id: ${LOCAL_KAKAO_CLIENT_ID}
       redirect-uri: ${LOCAL_KAKAO_REDIRECT_URI}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,6 +17,7 @@ spring:
 
   auth:
     success-redirect-url: ${PROD_KAKAO_SUCCESS_REDIRECT_URL}
+    first-login-redirect-url: ${PROD_KAKAO_FIRST_LOGIN_REDIRECT_URL}
     kakao:
       client-id: ${PROD_KAKAO_CLIENT_ID}
       redirect-uri: ${PROD_KAKAO_REDIRECT_URI}


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 카카오 첫 로그인 시 닉네임, 생년월일 없이 AT, RT가 발급되는 이슈 발생

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 첫 로그인 시 바로 AT, RT를 발급하지 않고, temp token을 통해 유예 기간을 만듬

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트