### PR TITLE
feat: 채팅방 입장 메시지 기능 추가 및 필드 이름 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomServiceImpl.java
@@ -6,10 +6,13 @@ import connectripbe.connectrip_be.accompany_status.repository.AccompanyStatusJpa
 import connectripbe.connectrip_be.chat.dto.ChatRoomEnterDto;
 import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
 import connectripbe.connectrip_be.chat.dto.ChatRoomMemberResponse;
+import connectripbe.connectrip_be.chat.entity.ChatMessage;
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
 import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
 import connectripbe.connectrip_be.chat.entity.type.ChatRoomType;
+import connectripbe.connectrip_be.chat.entity.type.MessageType;
+import connectripbe.connectrip_be.chat.repository.ChatMessageRepository;
 import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
 import connectripbe.connectrip_be.chat.repository.ChatRoomRepository;
 import connectripbe.connectrip_be.chat.service.ChatRoomMemberService;
@@ -39,6 +42,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     private final AccompanyPostRepository accompanyPostRepository;
     private final AccompanyStatusJpaRepository accompanyStatusJpaRepository;
     private final PendingListRepository pendingListRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     private final ChatRoomMemberService chatRoomMemberService;
 
@@ -108,6 +112,18 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         // 방장 설정
         chatRoom.setInitialLeader(leaderMember);
+
+        ChatMessage chatMessage = ChatMessage.builder()
+                .type(MessageType.ENTER)
+                .chatRoomId(chatRoom.getId())
+                .senderId(memberId)
+                .senderNickname(leaderMember.getMember().getNickname())
+                .senderProfileImage(leaderMember.getMember().getProfileImagePath())
+                .content(leaderMember.getMember().getNickname() + "님이 채팅방에 입장하셨습니다.")
+                .infoFlag(true)
+                .build();
+
+        chatMessageRepository.save(chatMessage);
     }
 
 

--- a/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/post/entity/AccompanyPostEntity.java
@@ -32,7 +32,7 @@ public class AccompanyPostEntity extends BaseEntity {
     private long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member__id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private MemberEntity memberEntity;
 
     @Column(nullable = false)


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR은 다음과 같은 문제를 해결합니다:
- 채팅방 입장 시 자동으로 입장 메시지를 생성하는 기능이 없었습니다.
- AccompanyPostEntity에서 `member_id` 필드에 잘못된 언더스코어(`__`)가 포함되어 있었습니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
- **채팅방 입장 메시지 기능 추가**:
  - 사용자가 채팅방에 입장할 때 자동으로 입장 메시지를 생성하고 이를 DB에 저장하는 로직을 추가했습니다.
  - 입장 메시지는 `MessageType.ENTER`로 설정되며, `infoFlag`를 `true`로 설정하여 시스템 메시지임을 구분했습니다.
  
- **필드 이름 수정**:
  - `AccompanyPostEntity`에서 `member__id` 필드의 잘못된 언더스코어를 수정하여 `member_id`로 변경했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없음

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트