### PR TITLE
fix: 메시지 생성 시간 UTC 포맷으로 변경

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
@@ -3,6 +3,8 @@ package connectripbe.connectrip_be.chat.dto;
 import connectripbe.connectrip_be.chat.entity.ChatMessage;
 import connectripbe.connectrip_be.chat.entity.type.MessageType;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 
 @Builder
@@ -15,8 +17,11 @@ public record ChatMessageResponse(
         String senderProfileImage,
         String content,
         Boolean infoFlag,
-        LocalDateTime createdAt
+        String createdAt
 ) {
+    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd'T'HH:mm:ss'Z'");
+
     public static ChatMessageResponse fromEntity(ChatMessage chatMessage) {
         return ChatMessageResponse.builder()
                 .id(chatMessage.getId())
@@ -27,7 +32,15 @@ public record ChatMessageResponse(
                 .senderProfileImage(chatMessage.getSenderProfileImage())
                 .content(chatMessage.getContent())
                 .infoFlag(chatMessage.isInfoFlag())
-                .createdAt(chatMessage.getCreatedAt())
+                .createdAt(formatToUTC(chatMessage.getCreatedAt()))
                 .build();
+    }
+
+    private static String formatToUTC(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        return dateTime.atZone(ZoneId.systemDefault())
+                .format(UTC_FORMATTER);
     }
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 채팅 메시지 시간에 UTC가 적용이 되지 않는 휴먼 에러

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- ChatMessageResponse의 createdAt 필드를 String 타입으로 변경했습니다.
- 메시지 생성 시간을 UTC 포맷("yyyy-MM-dd'T'HH:mm:ss'Z'")으로 변환하는 로직을 추가했습니다.
- LocalDateTime을 String으로 변환하여 시간대 문제를 해결했습니다.
### 핵심 변경 사항 외에 추가적으로 변경된 부분

<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 