### PR TITLE
add: 채팅 메시지 내용 길이 검증 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageRequest.java
@@ -1,11 +1,14 @@
 package connectripbe.connectrip_be.chat.dto;
 
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record ChatMessageRequest(
         Long chatRoomId,
         Long senderId,
+
+        @Size(max = 256, message = "채팅 내용은 256자 이내로 입력해주세요.")
         String content,
         Boolean infoFlag
 ) {


### PR DESCRIPTION
### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- 채팅 메시지의 최대 길이를 256자로 제한하는 검증 로직을 추가했습니다.
- `@Size` 어노테이션을 사용하여 메시지 길이를 검증하고 사용자에게 에러 메시지를 제공합니다.


### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 