### PR TITLE
refactor: 동행 게시글 삭제 시 동행 상태를 CLOSED로 변경

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/post/service/impl/AccompanyPostServiceImpl.java
@@ -123,9 +123,7 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
     public AccompanyPostResponse readAccompanyPost(long id) {
         AccompanyPostEntity accompanyPostEntity = findAccompanyPostEntity(id);
 
-        AccompanyStatusEntity accompanyStatusEntity = accompanyStatusJpaRepository
-                .findTopByAccompanyPostEntityOrderByCreatedAtDesc(accompanyPostEntity)
-                .orElseThrow(NotFoundAccompanyPostException::new);
+        AccompanyStatusEntity accompanyStatusEntity = getAccompanyStatusEntity(accompanyPostEntity);
 
         ChatRoomEntity chatRoom = chatRoomRepository.findByAccompanyPost_Id(id)
                 .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
@@ -143,9 +141,7 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
 
         validateAccompanyPostOwnership(memberEntity, accompanyPostEntity);
 
-        AccompanyStatusEntity accompanyStatusEntity = accompanyStatusJpaRepository
-                .findTopByAccompanyPostEntityOrderByCreatedAtDesc(accompanyPostEntity)
-                .orElseThrow(NotFoundAccompanyPostException::new);
+        AccompanyStatusEntity accompanyStatusEntity = getAccompanyStatusEntity(accompanyPostEntity);
 
         accompanyPostEntity.updateAccompanyPost(
                 request.title(),
@@ -172,7 +168,16 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
 
         validateAccompanyPostOwnership(memberEntity, accompanyPostEntity);
 
+        // 동행 게시글 삭제 시 동행 상태를 CLOSED 로 변경
+        getAccompanyStatusEntity(accompanyPostEntity).changeAccompanyStatus(AccompanyStatusEnum.CLOSED);
+
         accompanyPostEntity.deleteEntity();
+    }
+
+    private AccompanyStatusEntity getAccompanyStatusEntity(AccompanyPostEntity accompanyPostEntity) {
+        return accompanyStatusJpaRepository
+                .findTopByAccompanyPostEntityOrderByCreatedAtDesc(accompanyPostEntity)
+                .orElseThrow(NotFoundAccompanyPostException::new);
     }
 
     @Override


### PR DESCRIPTION
### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 동행 게시글 삭제 시 동행 상태를 CLOSED로 변경하도록 로직 추가.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-  동행 상태 엔티티 조회 로직을 getAccompanyStatusEntity 메서드로 통합하여 중복 코드 제거.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 