### PR TITLE
Feat rate limiting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,8 @@ dependencies {
     // Messaging
     implementation 'org.springframework:spring-messaging'
 
+    //Bucket4j
+    implementation 'com.bucket4j:bucket4j-redis:8.7.0'
 
 }
 

--- a/src/main/java/connectripbe/connectrip_be/auth/jwt/JwtUserDetailService.java
+++ b/src/main/java/connectripbe/connectrip_be/auth/jwt/JwtUserDetailService.java
@@ -1,7 +1,6 @@
 package connectripbe.connectrip_be.auth.jwt;
 
 
-
 import static connectripbe.connectrip_be.global.exception.type.ErrorCode.USER_NOT_FOUND;
 
 import connectripbe.connectrip_be.auth.jwt.dto.CustomUserDto;
@@ -17,23 +16,28 @@ import org.springframework.stereotype.Service;
 
 
 /**
- * 사용자를 인증하기 위해 UserDetailsService 인터페이스를 구현한 클래스
- * 주어진 이메일 기반으로 사용자 정보를 로드
- * JWT 기반 인증을 위해 필요한 UserDetails 객체를 반환
+ * 사용자를 인증하기 위해 UserDetailsService 인터페이스를 구현한 클래스 주어진 이메일 기반으로 사용자 정보를 로드 JWT 기반 인증을 위해 필요한 UserDetails 객체를 반환
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtUserDetailService implements UserDetailsService {
 
-      private final MemberJpaRepository memberJpaRepository;
+    private final MemberJpaRepository memberJpaRepository;
 
-      @Override
-      public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-            MemberEntity memberEntity = memberJpaRepository.findByEmail(email)
-                    .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+        MemberEntity memberEntity = memberJpaRepository.findByEmail(email)
+                .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
 
-            return new JwtUserDetails(CustomUserDto.fromEntity(memberEntity));
-      }
+        return new JwtUserDetails(CustomUserDto.fromEntity(memberEntity));
+    }
+
+
+    public UserDetails loadUserById(Long memberId) {
+        MemberEntity memberEntity = memberJpaRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+        return new JwtUserDetails(CustomUserDto.fromEntity(memberEntity));
+    }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomMemberEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomMemberEntity.java
@@ -3,6 +3,7 @@ package connectripbe.connectrip_be.chat.entity;
 import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
 import connectripbe.connectrip_be.global.entity.BaseEntity;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -12,12 +13,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity(name = "chat_room_member")
+@Table(name = "chat_room_member")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,10 +42,13 @@ public class ChatRoomMemberEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ChatRoomMemberStatus status;
 
+    @Column(name = "is_location_sharing_enabled")
     private boolean isLocationSharingEnabled;
 
+    @Column(name = "last_latitude")
     private Double lastLatitude;
 
+    @Column(name = "last_longitude")
     private Double lastLongitude;
 
     // 연관관계 메서드

--- a/src/main/java/connectripbe/connectrip_be/comment/service/impl/AccompanyCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/service/impl/AccompanyCommentServiceImpl.java
@@ -7,15 +7,15 @@ import connectripbe.connectrip_be.comment.repository.AccompanyCommentRepository;
 import connectripbe.connectrip_be.comment.service.AccompanyCommentService;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import connectripbe.connectrip_be.global.util.bucket4j.annotation.RateLimit;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
 import connectripbe.connectrip_be.post.repository.AccompanyPostRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,16 +26,15 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     private final AccompanyPostRepository accompanyPostRepository;
 
     /**
-     * 댓글을 생성하는 메서드.
-     * 사용자 이메일을 통해 MemberEntity 를 조회하고, 게시물 ID를 통해 AccompanyPostEntity 를 조회한 후
-     * AccompanyCommentEntity 를 생성하여 데이터베이스에 저장
+     * 댓글을 생성하는 메서드. 사용자 이메일을 통해 MemberEntity 를 조회하고, 게시물 ID를 통해 AccompanyPostEntity 를 조회한 후 AccompanyCommentEntity 를
+     * 생성하여 데이터베이스에 저장
      *
      * @param memberId 댓글 작성자의 아이디
      * @param request  댓글 생성 요청 정보 (게시물 ID, 댓글 내용 포함)
      * @return 생성된 댓글의 정보를 담은 AccompanyCommentResponse 객체
      */
     @Override
-    @Transactional
+    @RateLimit(capacity = 10, refillTokens = 10)
     public AccompanyCommentResponse createComment(Long memberId, AccompanyCommentRequest request) {
         MemberEntity member = getMember(memberId);
         AccompanyPostEntity post = getPost(request.getPostId());
@@ -46,13 +45,13 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
                 .content(request.getContent())
                 .build();
 
-        return AccompanyCommentResponse.fromEntity(accompanyCommentRepository.save(comment));
+        accompanyCommentRepository.save(comment);
+
+        return AccompanyCommentResponse.fromEntity(comment);
     }
 
     /**
-     * 댓글을 수정하는 메서드.
-     * 주어진 댓글 ID를 통해 AccompanyCommentEntity를 조회하고,
-     * 수정 권한이 있는지 확인한 후 댓글 내용을 업데이트
+     * 댓글을 수정하는 메서드. 주어진 댓글 ID를 통해 AccompanyCommentEntity를 조회하고, 수정 권한이 있는지 확인한 후 댓글 내용을 업데이트
      *
      * @param memberId  수정하려는 사용자의 아이디
      * @param request   댓글 수정 요청 정보 (수정된 댓글 내용 포함)
@@ -74,9 +73,7 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     }
 
     /**
-     * 댓글을 삭제하는 메서드.
-     * 주어진 댓글 ID를 통해 AccompanyCommentEntity를 조회한 후, 삭제 권한이 있는지 확인하고
-     * 해당 댓글을 데이터베이스에서 삭제
+     * 댓글을 삭제하는 메서드. 주어진 댓글 ID를 통해 AccompanyCommentEntity를 조회한 후, 삭제 권한이 있는지 확인하고 해당 댓글을 데이터베이스에서 삭제
      *
      * @param memberId  삭제하려는 사용자의 아이디
      * @param commentId 삭제할 댓글의 ID
@@ -93,8 +90,7 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     }
 
     /**
-     * 특정 게시물에 달린 모든 댓글을 조회하는 메서드.
-     * 주어진 게시물 ID를 통해 해당 게시물에 달린 삭제되지 않은 댓글 목록을 조회한 후, 이를 DTO로 변환하여 반환
+     * 특정 게시물에 달린 모든 댓글을 조회하는 메서드. 주어진 게시물 ID를 통해 해당 게시물에 달린 삭제되지 않은 댓글 목록을 조회한 후, 이를 DTO로 변환하여 반환
      *
      * @param postId 댓글을 조회할 게시물의 ID
      * @return 해당 게시물에 달린 댓글들의 정보를 담은 List<AccompanyCommentResponse> 객체
@@ -102,15 +98,15 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     @Override
     @Transactional(readOnly = true)
     public List<AccompanyCommentResponse> getCommentsByPost(Long postId) {
-        List<AccompanyCommentEntity> comments = accompanyCommentRepository.findByAccompanyPostEntity_IdAndDeletedAtIsNull(postId);
+        List<AccompanyCommentEntity> comments = accompanyCommentRepository.findByAccompanyPostEntity_IdAndDeletedAtIsNull(
+                postId);
         return comments.stream()
                 .map(AccompanyCommentResponse::fromEntity)
                 .toList();
     }
 
     /**
-     * 주어진 댓글 ID로 댓글을 조회하는 메서드.
-     * 만약 해당 댓글이 존재하지 않으면 GlobalException 을 발생
+     * 주어진 댓글 ID로 댓글을 조회하는 메서드. 만약 해당 댓글이 존재하지 않으면 GlobalException 을 발생
      *
      * @param commentId 조회할 댓글의 ID
      * @return 조회된 AccompanyCommentEntity 객체
@@ -121,8 +117,7 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     }
 
     /**
-     * 주어진 게시물 ID로 게시물을 조회하는 메서드.
-     * 만약 해당 게시물이 존재하지 않으면 GlobalException을 발생
+     * 주어진 게시물 ID로 게시물을 조회하는 메서드. 만약 해당 게시물이 존재하지 않으면 GlobalException을 발생
      *
      * @param postId 조회할 게시물의 ID
      * @return 조회된 AccompanyPostEntity 객체
@@ -133,8 +128,7 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     }
 
     /**
-     * 주어진 이메일로 회원을 조회하는 메서드.
-     * 만약 해당 이메일로 등록된 회원이 존재하지 않으면 GlobalException을 발생
+     * 주어진 이메일로 회원을 조회하는 메서드. 만약 해당 이메일로 등록된 회원이 존재하지 않으면 GlobalException을 발생
      *
      * @param memberId 조회할 회원의 아이디
      * @return 조회된 MemberEntity 객체
@@ -145,8 +139,7 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     }
 
     /**
-     * 댓글 작성자와 요청한 사용자가 일치하는지 확인하는 메서드.
-     * 만약 일치하지 않으면 GlobalException을 발생
+     * 댓글 작성자와 요청한 사용자가 일치하는지 확인하는 메서드. 만약 일치하지 않으면 GlobalException을 발생
      *
      * @param memberId 요청한 사용자의 아이디
      * @param comment  조회된 AccompanyCommentEntity 객체

--- a/src/main/java/connectripbe/connectrip_be/communitycomment/service/impl/CommunityCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/communitycomment/service/impl/CommunityCommentServiceImpl.java
@@ -9,6 +9,7 @@ import connectripbe.connectrip_be.communitypost.entity.CommunityPostEntity;
 import connectripbe.connectrip_be.communitypost.repository.CommunityPostRepository;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import connectripbe.connectrip_be.global.util.bucket4j.annotation.RateLimit;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
 import java.util.List;
@@ -33,16 +34,16 @@ public class CommunityCommentServiceImpl implements CommunityCommentService {
      * @param request  댓글 생성 요청 정보 (게시물 ID, 댓글 내용 포함)
      * @return 생성된 댓글 정보를 담은 CommunityCommentResponse 객체
      */
+    @RateLimit(capacity = 10, refillTokens = 10)
     @Override
-    @Transactional
     public CommunityCommentResponse createComment(Long memberId, CommunityCommentRequest request) {
         MemberEntity member = getMember(memberId);
 
         CommunityPostEntity post = getPost(request.getPostId());
 
         CommunityCommentEntity comment = request.toEntity(post, member);
-
-        return CommunityCommentResponse.fromEntity(communityCommentRepository.save(comment));
+        communityCommentRepository.save(comment);
+        return CommunityCommentResponse.fromEntity(comment);
     }
 
     /**

--- a/src/main/java/connectripbe/connectrip_be/communitypost/service/impl/CommunityPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/communitypost/service/impl/CommunityPostServiceImpl.java
@@ -8,6 +8,7 @@ import connectripbe.connectrip_be.communitypost.repository.CommunityPostReposito
 import connectripbe.connectrip_be.communitypost.service.CommunityPostService;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import connectripbe.connectrip_be.global.util.bucket4j.annotation.RateLimit;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
 import java.util.List;
@@ -29,6 +30,7 @@ public class CommunityPostServiceImpl implements CommunityPostService {
      * @param memberId 게시글 작성자의 ID
      * @return 생성된 게시글의 정보를 담은 CommunityPostResponse 객체
      */
+    @RateLimit
     @Override
     public CommunityPostResponse createPost(CreateCommunityPostRequest request, Long memberId) {
         MemberEntity memberEntity = findMemberByIdAndValidate(memberId);

--- a/src/main/java/connectripbe/connectrip_be/global/config/RedisConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package connectripbe.connectrip_be.global.config;
 
+import io.lettuce.core.RedisClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
@@ -21,6 +22,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 @RequiredArgsConstructor
 public class RedisConfig {
+
+    private static final String PREFIX = "redis://";
 
     @Value("${spring.data.redis.host}")
     private String host;
@@ -67,5 +70,10 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new StringRedisSerializer());
 
         return redisTemplate;
+    }
+
+    @Bean(name = "lettuceRedisClient")
+    public RedisClient redisClient() {
+        return RedisClient.create(PREFIX + host + ":" + port);
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -81,7 +81,6 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이메일로 사용자를 찾을 수 없습니다."),
     NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),  // 리뷰 관련 에러 추가
 
-
     CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방 참여자를 찾을 수 없습니다."),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방을 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 글을 찾을 수 없습니다."),
@@ -116,6 +115,12 @@ public enum ErrorCode {
      * 405 Method Not Allowed
      */
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),
+
+    /**
+     * 429 Too Many Requests
+     */
+
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/annotation/RateLimit.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/annotation/RateLimit.java
@@ -1,0 +1,16 @@
+package connectripbe.connectrip_be.global.util.bucket4j.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RateLimit {
+    int capacity() default 5;  // 기본 용량
+
+    int refillTokens() default 5;  // 재충전되는 토큰 수
+
+    long refillDurationSeconds() default 60;  // 재충전 주기(초 단위)
+}

--- a/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/aop/RateLimitAspect.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/aop/RateLimitAspect.java
@@ -23,6 +23,13 @@ public class RateLimitAspect {
 
     private final RateLimiterService rateLimiterService;
 
+    /**
+     * 메서드 실행 전, 사용자에 대해 RateLimit 을 확인하여 제한을 초과하지 않는지 검증.
+     *
+     * @param joinPoint AOP 에서 제공하는 현재 메서드 실행 정보
+     * @return 메서드 실행 결과
+     * @throws Throwable RateLimit 에 의해 제한된 경우 예외가 발생
+     */
     @Around("@annotation(connectripbe.connectrip_be.global.util.bucket4j.annotation.RateLimit)")
     public Object checkRateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();

--- a/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/aop/RateLimitAspect.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/aop/RateLimitAspect.java
@@ -1,0 +1,51 @@
+package connectripbe.connectrip_be.global.util.bucket4j.aop;
+
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import connectripbe.connectrip_be.global.util.bucket4j.annotation.RateLimit;
+import connectripbe.connectrip_be.global.util.bucket4j.service.RateLimiterService;
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+@Aspect
+public class RateLimitAspect {
+
+    private final RateLimiterService rateLimiterService;
+
+    @Around("@annotation(connectripbe.connectrip_be.global.util.bucket4j.annotation.RateLimit)")
+    public Object checkRateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        RateLimit rateLimit = method.getAnnotation(RateLimit.class);
+
+        int capacity = rateLimit.capacity();
+        int refillTokens = rateLimit.refillTokens();
+        long refillDurationSeconds = rateLimit.refillDurationSeconds();
+
+        // SecurityContext에서 사용자 ID를 가져옴
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        // API 이름 또는 경로를 사용하여 버킷을 구분
+        String apiEndpoint = method.getName(); // 여기서 method.getName()을 사용해 메서드 이름을 API 경로로 활용
+
+        log.info("Authenticated user ID: {}, API: {}", userId, apiEndpoint);
+
+        if (!rateLimiterService.tryConsume(userId, apiEndpoint, capacity, refillTokens, refillDurationSeconds)) {
+            throw new GlobalException(ErrorCode.TOO_MANY_REQUESTS);
+        }
+
+        return joinPoint.proceed();
+    }
+
+}

--- a/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/config/RateLimitConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/config/RateLimitConfig.java
@@ -1,0 +1,59 @@
+package connectripbe.connectrip_be.global.util.bucket4j.config;
+
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Slf4j
+@RequiredArgsConstructor
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@Configuration
+public class RateLimitConfig {
+
+    // 버킷에 담길 수 있는 토큰의 최대 수
+    private static final int CAPACITY = 5;
+
+    // REFILL_DURATION 으로 지정된 시간 동안 버킷에 추가될 토큰의 수
+    private static final int REFILL_TOKEN_AMOUNT = 5;
+
+    // 토큰이 재충전되는 빈도
+    private static final Duration REFILL_DURATION = Duration.ofSeconds(60);
+
+    private final RedisClient lettuceRedisClient;
+
+    @Bean
+    public LettuceBasedProxyManager<String> lettuceBasedProxyManager() {
+        StatefulRedisConnection<String, byte[]> connect =
+                lettuceRedisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
+
+        return LettuceBasedProxyManager.builderFor(connect)
+                // 버킷 만료 정책(최대 용량으로 채워지는데 필요한 60초 동안 버킷으로 유지)
+                .withExpirationStrategy(
+                        ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(Duration.ofSeconds(60)))
+                .build();
+    }
+
+    @Bean
+    public BucketConfiguration bucketConfiguration() {
+        return BucketConfiguration.builder()
+                // 새로운 방식으로 토큰 충전: 일정한 시간 간격으로 충전(그리디 방식)
+                .addLimit(Bandwidth.builder()
+                        .capacity(CAPACITY)
+                        .refillGreedy(REFILL_TOKEN_AMOUNT, REFILL_DURATION)
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/config/RateLimitConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/config/RateLimitConfig.java
@@ -34,6 +34,12 @@ public class RateLimitConfig {
 
     private final RedisClient lettuceRedisClient;
 
+
+    /**
+     * Redis 에 연결된 Lettuce 기반의 Bucket4j ProxyManager 를 생성.
+     *
+     * @return Lettuce 기반의 ProxyManager 인스턴스
+     */
     @Bean
     public LettuceBasedProxyManager<String> lettuceBasedProxyManager() {
         StatefulRedisConnection<String, byte[]> connect =
@@ -46,6 +52,11 @@ public class RateLimitConfig {
                 .build();
     }
 
+    /**
+     * Bucket4j의 기본 버킷 구성을 설정. 기본 설정으로는 용량과 충전 빈도가 적용.
+     *
+     * @return BucketConfiguration 인스턴스
+     */
     @Bean
     public BucketConfiguration bucketConfiguration() {
         return BucketConfiguration.builder()

--- a/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/service/RateLimiterService.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/service/RateLimiterService.java
@@ -20,6 +20,16 @@ public class RateLimiterService {
 
     private final RateLimitConfig rateLimitConfig;
 
+    /**
+     * 주어진 사용자 ID와 API 엔드포인트에 대해 레이트 리미트를 적용한 토큰 소비 시도를 수행.
+     *
+     * @param userId                사용자 ID
+     * @param apiEndpoint           API 엔드포인트 이름 또는 경로
+     * @param capacity              버킷의 최대 용량
+     * @param refillTokens          버킷이 충전되는 토큰 수
+     * @param refillDurationSeconds 토큰 충전 주기 (초 단위)
+     * @return 토큰이 소비되었으면 true, 그렇지 않으면 false
+     */
     public boolean tryConsume(String userId, String apiEndpoint, int capacity, int refillTokens,
                               long refillDurationSeconds) {
         // userId와 api Endpoint로 고유한 키 생성
@@ -36,6 +46,15 @@ public class RateLimiterService {
         return probe.isConsumed();
     }
 
+    /**
+     * 주어진 버킷 키와 설정에 따라 버킷을 생성하거나 기존 버킷을 반환.
+     *
+     * @param bucketKey             고유한 버킷 키
+     * @param capacity              버킷의 최대 용량
+     * @param refillTokens          버킷이 충전되는 토큰 수
+     * @param refillDurationSeconds 토큰 충전 주기 (초 단위)
+     * @return 설정된 버킷 객체
+     */
     private Bucket getOrCreateBucket(String bucketKey, int capacity, int refillTokens, long refillDurationSeconds) {
         BucketConfiguration configuration = BucketConfiguration.builder()
                 .addLimit(Bandwidth.builder()
@@ -49,15 +68,35 @@ public class RateLimiterService {
                 .build(bucketKey, () -> configuration);
     }
 
+    /**
+     * 버킷에서 토큰을 소비하고 결과를 반환.
+     *
+     * @param bucket 소비할 버킷 객체
+     * @return 소비된 토큰의 결과
+     */
     private ConsumptionProbe consumeToken(Bucket bucket) {
         return bucket.tryConsumeAndReturnRemaining(1);
     }
 
+
+    /**
+     * 소비된 토큰에 대한 정보를 로그로 기록.
+     *
+     * @param bucketKey 버킷 키
+     * @param probe     토큰 소비 결과 객체
+     */
     private void logConsumption(String bucketKey, ConsumptionProbe probe) {
         log.info("Bucket Key: {}, tryConsume: {}, remainToken: {}, tryTime: {}",
                 bucketKey, probe.isConsumed(), probe.getRemainingTokens(), LocalDateTime.now());
     }
 
+
+    /**
+     * 토큰이 소비되지 못했을 때 예외를 발생.
+     *
+     * @param probe 토큰 소비 결과 객체
+     * @throws GlobalException 요청이 너무 많은 경우 예외를 발생
+     */
     private void handleNotConsumed(ConsumptionProbe probe) {
         if (!probe.isConsumed()) {
             throw new GlobalException(ErrorCode.TOO_MANY_REQUESTS);

--- a/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/service/RateLimiterService.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/service/RateLimiterService.java
@@ -1,0 +1,72 @@
+package connectripbe.connectrip_be.global.util.bucket4j.service;
+
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import connectripbe.connectrip_be.global.util.bucket4j.config.RateLimitConfig;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.ConsumptionProbe;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RateLimiterService {
+
+    private final RateLimitConfig rateLimitConfig;
+
+    public boolean tryConsume(String userId, String apiEndpoint, int capacity, int refillTokens,
+                              long refillDurationSeconds) {
+        // userId와 api Endpoint로 고유한 키 생성
+        String bucketKey = userId + ":" + apiEndpoint;
+
+        Bucket bucket = getOrCreateBucket(bucketKey, capacity, refillTokens, refillDurationSeconds);
+
+        ConsumptionProbe probe = consumeToken(bucket);
+
+        logConsumption(bucketKey, probe);
+
+        handleNotConsumed(probe);
+
+        return probe.isConsumed();
+    }
+
+    private Bucket getOrCreateBucket(String bucketKey, int capacity, int refillTokens, long refillDurationSeconds) {
+        BucketConfiguration configuration = BucketConfiguration.builder()
+                .addLimit(Bandwidth.builder()
+                        .capacity(capacity)
+                        .refillGreedy(refillTokens, Duration.ofSeconds(refillDurationSeconds))
+                        .build())
+                .build();
+
+        return rateLimitConfig.lettuceBasedProxyManager()
+                .builder()
+                .build(bucketKey, () -> configuration);
+    }
+
+    private ConsumptionProbe consumeToken(Bucket bucket) {
+        return bucket.tryConsumeAndReturnRemaining(1);
+    }
+
+    private void logConsumption(String bucketKey, ConsumptionProbe probe) {
+        log.info("Bucket Key: {}, tryConsume: {}, remainToken: {}, tryTime: {}",
+                bucketKey, probe.isConsumed(), probe.getRemainingTokens(), LocalDateTime.now());
+    }
+
+    private void handleNotConsumed(ConsumptionProbe probe) {
+        if (!probe.isConsumed()) {
+            throw new GlobalException(ErrorCode.TOO_MANY_REQUESTS);
+        }
+    }
+
+    public long getRemainToken(String bucketKey) {
+        Bucket bucket = getOrCreateBucket(bucketKey, 5, 5, 60);
+        return bucket.getAvailableTokens();
+    }
+
+}


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 다음과 같은 문제를 해결합니다:
- Rate Limiting 기능이 없는 상태에서, 사용자 요청을 제어할 수 없었던 문제를 해결하고자 Rate Limiting 기능을 추가했습니다.
- Redis와 Bucket4j를 사용하여 API 요청을 제한하는 기능을 추가했습니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
>문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- **Bucket4j 라이브러리 추가**: `build.gradle`에 `Bucket4j` Redis 지원 라이브러리를 추가했습니다.
- **Rate Limiting 기능 추가**: 
  - `RateLimit` 어노테이션을 추가하여 메서드별로 요청 제한을 설정할 수 있습니다.
  - `RateLimiterService`와 `RateLimitAspect`를 추가하여 Redis를 기반으로 사용자의 요청을 제어할 수 있게 했습니다.
- **Redis 설정 변경**: `RedisConfig`에 Lettuce 클라이언트를 사용하여 Redis 연결을 설정했습니다.
- **ChatRoomMemberEntity에 위치 공유 필드 추가**:
  - `isLocationSharingEnabled`, `lastLatitude`, `lastLongitude` 필드를 추가하여 채팅방 참여자의 위치 공유 기능을 구현했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없음

### 테스트
- [ ] 테스트 코드 작성 완료
- [x] API 테스트 완료