### PR TITLE
fix: RateLimiterService의 토큰 충전 방식 수정 및 불필요한 설정 제거

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/config/RateLimitConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/config/RateLimitConfig.java
@@ -1,8 +1,6 @@
 package connectripbe.connectrip_be.global.util.bucket4j.config;
 
 
-import io.github.bucket4j.Bandwidth;
-import io.github.bucket4j.BucketConfiguration;
 import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
 import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager;
 import io.lettuce.core.RedisClient;
@@ -23,17 +21,7 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 @Configuration
 public class RateLimitConfig {
 
-    // 버킷에 담길 수 있는 토큰의 최대 수
-    private static final int CAPACITY = 5;
-
-    // REFILL_DURATION 으로 지정된 시간 동안 버킷에 추가될 토큰의 수
-    private static final int REFILL_TOKEN_AMOUNT = 5;
-
-    // 토큰이 재충전되는 빈도
-    private static final Duration REFILL_DURATION = Duration.ofSeconds(60);
-
     private final RedisClient lettuceRedisClient;
-
 
     /**
      * Redis 에 연결된 Lettuce 기반의 Bucket4j ProxyManager 를 생성.
@@ -49,22 +37,6 @@ public class RateLimitConfig {
                 // 버킷 만료 정책(최대 용량으로 채워지는데 필요한 60초 동안 버킷으로 유지)
                 .withExpirationStrategy(
                         ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(Duration.ofSeconds(60)))
-                .build();
-    }
-
-    /**
-     * Bucket4j의 기본 버킷 구성을 설정. 기본 설정으로는 용량과 충전 빈도가 적용.
-     *
-     * @return BucketConfiguration 인스턴스
-     */
-    @Bean
-    public BucketConfiguration bucketConfiguration() {
-        return BucketConfiguration.builder()
-                // 새로운 방식으로 토큰 충전: 일정한 시간 간격으로 충전(그리디 방식)
-                .addLimit(Bandwidth.builder()
-                        .capacity(CAPACITY)
-                        .refillGreedy(REFILL_TOKEN_AMOUNT, REFILL_DURATION)
-                        .build())
                 .build();
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/service/RateLimiterService.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/bucket4j/service/RateLimiterService.java
@@ -59,7 +59,7 @@ public class RateLimiterService {
         BucketConfiguration configuration = BucketConfiguration.builder()
                 .addLimit(Bandwidth.builder()
                         .capacity(capacity)
-                        .refillGreedy(refillTokens, Duration.ofSeconds(refillDurationSeconds))
+                        .refillIntervally(refillTokens, Duration.ofSeconds(refillDurationSeconds))
                         .build())
                 .build();
 


### PR DESCRIPTION


### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [x]  refillIntervally로 설정 변경

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- RateLimiterService에서 토큰 충전 방식을 refillGreedy에서 refillIntervally로 변경했습니다.
- RateLimitConfig에서 불필요한 BucketConfiguration 관련 설정을 제거했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 