### PR TITLE
feat: 채팅 메시지 상태 관리 및 WebSocket 세션 관리 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/config/WebSocketConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/WebSocketConfig.java
@@ -1,24 +1,31 @@
 package connectripbe.connectrip_be.chat.config;
 
+import connectripbe.connectrip_be.chat.config.handler.StompPreHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final StompPreHandler stompPreHandler;
+
     @Value("${allowed.origins}")
     private String allowedOrigins;
+
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 클라이언트가 WebSocket에 연결할 수 있는 엔드포인트를 등록.
         registry.addEndpoint("/ws/init")  // 클라이언트가 "/ws" 엔드포인트로 WebSocket 연결을 시도할 수 있도록 설정.
-                .setAllowedOrigins(allowedOrigins)  // 허용할 도메인을 설정.
+                .setAllowedOrigins(allowedOrigins)// 허용할 도메인을 설정.
                 .withSockJS();
     }
 
@@ -33,6 +40,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // 클라이언트가 메시지를 보낼 때 "/pub" 프리픽스를 사용.
         registry.setApplicationDestinationPrefixes("/pub");
 
+    }
 
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompPreHandler);
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
@@ -96,6 +96,7 @@ public class StompPreHandler implements ChannelInterceptor {
             for (String cookie : cookieHeader.split(";")) {
                 String[] cookiePair = cookie.split("=");
                 if (cookiePair.length == 2 && "accessToken".equals(cookiePair[0].trim())) {
+                    log.info("accessToken found in cookies: {}", cookiePair[1].trim());
                     return cookiePair[1].trim();
                 }
             }

--- a/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
@@ -1,0 +1,129 @@
+package connectripbe.connectrip_be.chat.config.handler;
+
+import connectripbe.connectrip_be.auth.jwt.JwtProvider;
+import connectripbe.connectrip_be.chat.config.service.ChatSessionService;
+import connectripbe.connectrip_be.chat.dto.ChatRoomSessionDto;
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompPreHandler implements ChannelInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private final ChatSessionService chatSessionService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        assert accessor != null;
+
+        try {
+            if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                handleConnect(accessor);
+            } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+                handleSubscribe(accessor);
+            } else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+                handleDisconnect(accessor);
+            }
+        } catch (Exception e) {
+            log.error("Error occurred while processing STOMP message: {}", e.getMessage());
+            throw e;
+        }
+
+        return message;
+    }
+
+    private void handleConnect(StompHeaderAccessor accessor) {
+        String accessToken = resolveTokenFromCookie(accessor);
+
+        if (!jwtProvider.validateToken(accessToken)) {
+            throw new GlobalException(ErrorCode.INVALID_TOKEN);
+        }
+
+        Long userId = jwtProvider.getMemberIdFromToken(accessToken);
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(userId, null, null);
+        accessor.setUser(authenticationToken);
+        log.info("User {} connected via WebSocket", userId);
+    }
+
+    private void handleSubscribe(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        Long chatRoomId = extractChatRoomIdFromDestination(Objects.requireNonNull(destination));
+        Long memberId = Long.parseLong(Objects.requireNonNull(accessor.getUser()).getName());
+        String sessionId = accessor.getSessionId();
+
+        chatSessionService.saveUserSession(chatRoomId, memberId, sessionId);
+        log.info("User {} subscribed to chat room {}, session ID: {}", memberId, chatRoomId, sessionId);
+
+    }
+
+    private void handleDisconnect(StompHeaderAccessor accessor) {
+        String sessionId = accessor.getSessionId();
+        ChatRoomSessionDto sessionDto = chatSessionService.getUserSession(sessionId);
+
+        if (sessionDto == null) {
+            log.warn("Session not found for sessionId: {}", sessionId);
+            throw new GlobalException(ErrorCode.INVALID_SESSION);
+        }
+
+        Long chatRoomId = sessionDto.chatRoomId();
+        Long memberId = sessionDto.memberId();
+        chatSessionService.updateLastReadMessage(memberId, chatRoomId);
+        chatSessionService.removeUserSession(sessionId);
+        log.info("User {} disconnected from chat room {}, session ID: {}", memberId, chatRoomId, sessionId);
+    }
+
+    // 쿠키에서 accessToken 추출
+    private String resolveTokenFromCookie(StompHeaderAccessor accessor) {
+        String cookieHeader = accessor.getFirstNativeHeader("Cookie");
+        if (cookieHeader != null) {
+            for (String cookie : cookieHeader.split(";")) {
+                String[] cookiePair = cookie.split("=");
+                if (cookiePair.length == 2 && "accessToken".equals(cookiePair[0].trim())) {
+                    return cookiePair[1].trim();
+                }
+            }
+        }
+        log.error("accessToken not found in cookies");
+        throw new GlobalException(ErrorCode.TOKEN_NOT_FOUND);
+    }
+
+
+    // 쿠키에서 refreshToken 추출
+    private String resolveRefreshTokenFromCookie(StompHeaderAccessor accessor) {
+        String cookieHeader = accessor.getFirstNativeHeader("Cookie");
+        if (cookieHeader != null) {
+            for (String cookie : cookieHeader.split(";")) {
+                String[] cookiePair = cookie.split("=");
+                if ("refreshToken".equals(cookiePair[0].trim())) {
+                    return cookiePair[1].trim();
+                }
+            }
+        }
+        return null;
+    }
+
+
+    private Long extractChatRoomIdFromDestination(String destination) {
+        // "/sub/chat/room/{chatRoomId}" 형식에서 chatRoomId 추출
+        return Long.parseLong(destination.substring(destination.lastIndexOf('/') + 1));
+    }
+
+
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/config/service/ChatSessionService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/service/ChatSessionService.java
@@ -1,0 +1,51 @@
+package connectripbe.connectrip_be.chat.config.service;
+
+import connectripbe.connectrip_be.chat.dto.ChatRoomSessionDto;
+import connectripbe.connectrip_be.chat.repository.ChatMessageRepository;
+import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
+import connectripbe.connectrip_be.global.service.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatSessionService {
+
+    private static final String CHAT_ROOM_KEY_PREFIX = "chat_room_session:";
+
+
+    private final RedisService redisService;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    // 세션 저장 로직
+    public void saveUserSession(Long chatRoomId, Long memberId, String sessionId) {
+
+        ChatRoomSessionDto sessionDto = new ChatRoomSessionDto(chatRoomId, memberId);
+
+        redisService.updateToHash(CHAT_ROOM_KEY_PREFIX, sessionId, sessionDto);
+    }
+
+    // 세션 삭제 로직
+    public void removeUserSession(String sessionId) {
+        redisService.deleteHashKey(CHAT_ROOM_KEY_PREFIX, sessionId);
+    }
+
+    // 세션 조회 로직
+    public ChatRoomSessionDto getUserSession(String sessionId) {
+        return redisService.getChatRoomHashKey(CHAT_ROOM_KEY_PREFIX, sessionId, ChatRoomSessionDto.class);
+    }
+
+    // 마지막 메시지 업데이트 로직
+    public void updateLastReadMessage(Long memberId, Long chatRoomId) {
+        chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(chatRoomId)
+                .ifPresent(chatMessage -> {
+                    chatRoomMemberRepository.findByChatRoom_IdAndMember_Id(chatRoomId, memberId)
+                            .ifPresent(member -> {
+                                member.updateLastReadMessageId(chatMessage.getId());
+
+                                chatRoomMemberRepository.save(member);
+                            });
+                });
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomSessionDto.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomSessionDto.java
@@ -1,0 +1,7 @@
+package connectripbe.connectrip_be.chat.dto;
+
+public record ChatRoomSessionDto(
+        Long chatRoomId,
+        Long memberId
+) {
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomMemberEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomMemberEntity.java
@@ -51,6 +51,10 @@ public class ChatRoomMemberEntity extends BaseEntity {
     @Column(name = "last_longitude")
     private Double lastLongitude;
 
+    @Builder.Default
+    @Column
+    private String lastReadMessageId = null;
+
     // 연관관계 메서드
     public void assignChatRoom(ChatRoomEntity chatRoomEntity) {
         this.chatRoom = chatRoomEntity;
@@ -83,5 +87,9 @@ public class ChatRoomMemberEntity extends BaseEntity {
     public void updateLocation(Double latitude, Double longitude) {
         this.lastLatitude = latitude;
         this.lastLongitude = longitude;
+    }
+
+    public void updateLastReadMessageId(String lastReadMessageId) {
+        this.lastReadMessageId = lastReadMessageId;
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatMessageRepository.java
@@ -2,11 +2,14 @@ package connectripbe.connectrip_be.chat.repository;
 
 import connectripbe.connectrip_be.chat.entity.ChatMessage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
     List<ChatMessage> findByChatRoomId(Long chatRoomId);
-    // List<ChatMessage> findAllByChatRoomI
+
+    Optional<ChatMessage> findTopByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
+
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
@@ -20,7 +20,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMemberEn
             ChatRoomMemberStatus status,
             boolean isLocationTrackingEnabled);
 
-    Optional<ChatRoomMemberEntity> findByChatRoom_IdAndMember_Id(Long id, Long memberId);
+    Optional<ChatRoomMemberEntity> findByChatRoom_IdAndMember_Id(Long chatRoomId, Long memberId);
 
     Integer countByChatRoom_IdAndStatus(Long chatRoomId, ChatRoomMemberStatus chatRoomMemberStatus);
 

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
@@ -1,7 +1,6 @@
 package connectripbe.connectrip_be.chat.repository;
 
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/connectripbe/connectrip_be/global/exception/type/ErrorCode.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-
     /**
      * 400 Bad Request
      */
@@ -31,6 +30,7 @@ public enum ErrorCode {
     PENDING_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 신청한 상태입니다."),
     WRITE_YOURSELF(HttpStatus.BAD_REQUEST, "본인이 작성한 글은 신청할 수 없습니다."),
     NOT_CHATROOM_LEADER(HttpStatus.BAD_REQUEST, "채팅방 방장이 아닙니다."),
+    TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "토큰을 찾을 수 없습니다."),
 
 
     // Member, 사용자
@@ -73,6 +73,8 @@ public enum ErrorCode {
 
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다. 재발급이 필요합니다."),
 
+    INVALID_SESSION(HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다."),
+
     /**
      * 404 Not Found
      */
@@ -98,6 +100,8 @@ public enum ErrorCode {
     /**
      * 500 Internal Server Error
      */
+    REDIS_CAST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 데이터 변환 중 오류가 발생했습니다."),
+
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
 
     REDIRECT_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "리다이렉트에 실패했습니다."),
@@ -110,6 +114,7 @@ public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
     REVIEW_NOT_ALLOWED(HttpStatus.FORBIDDEN, "리뷰를 작성할 수 있는 상태가 아닙니다."), // 리뷰 관련 에러 추가
     REVIEW_DELETE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "리뷰를 삭제할 권한이 없습니다."),  // 리뷰 관련 에러 추가
+    UNAUTHORIZED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/src/main/java/connectripbe/connectrip_be/global/service/RedisService.java
+++ b/src/main/java/connectripbe/connectrip_be/global/service/RedisService.java
@@ -1,8 +1,8 @@
 package connectripbe.connectrip_be.global.service;
 
+import connectripbe.connectrip_be.global.exception.GlobalException;
+import connectripbe.connectrip_be.global.exception.type.ErrorCode;
 import java.time.Duration;
-import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class RedisService {
 
     private final RedisTemplate<String, Object> redisTemplate;
+
 
     /**
      * 주어진 Key 에 대응하는 데이터를 Redis DB 에서 조회
@@ -70,14 +71,22 @@ public class RedisService {
         }
     }
 
-    public void increaseHashData(String hashKey, String key) {
-        redisTemplate.opsForHash().increment(hashKey, key, 1);
+    // 해시 값을 Redis 에서 조회 (명확한 반환 타입을 받기 위해 Class<T> 사용)
+    public <T> T getChatRoomHashKey(String hashKey, String key, Class<T> clazz) {
+        Object value = redisTemplate.opsForHash().get(hashKey, key);
+        if (clazz.isInstance(value)) {
+            return clazz.cast(value);
+        }
+        throw new GlobalException(ErrorCode.REDIS_CAST_ERROR);
     }
 
-    public Map<Object, Object> hasHashKeys(String key) {
-        return redisTemplate.opsForHash().entries(key);
+
+    // Redis 에 해시 값 저장
+    public void updateToHash(String hashKey, String key, Object value) {
+        redisTemplate.opsForHash().put(hashKey, key, value);
     }
 
+    // Redis 에서 해시 값 삭제
     public void deleteHashKey(String hashKey, String key) {
         redisTemplate.opsForHash().delete(hashKey, key);
     }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 
- 채팅 메시지의 읽음 상태를 관리하고, 사용자 세션을 효과적으로 처리하여 WebSocket 통신 시 발생할 수 있는 세션과 읽음 상태의 문제를 해결

### ✨ 이 PR에서 핵심적으로 변경된 사항
1. **채팅 메시지 읽음 상태 관리 기능 추가**:
   - `ChatRoomMemberEntity`에 `lastReadMessageId` 필드를 추가하여 사용자가 마지막으로 읽은 메시지를 기록합니다.
   - 사용자가 채팅방에서 나갈 때 마지막 읽은 메시지를 업데이트하도록 `ChatSessionService`에서 처리합니다.

2. **채팅 세션 관리 서비스 추가**:
   - `ChatSessionService`를 통해 WebSocket 세션을 관리하며, 사용자의 세션을 Redis에 저장하고 삭제하는 로직을 구현했습니다.
   - `StompPreHandler`를 통해 STOMP 메시지 연결, 구독, 연결 종료 시 필요한 세션 및 토큰 처리를 수행합니다.

3. **신규 오류 코드 추가**:
   - `TOKEN_NOT_FOUND`, `INVALID_SESSION` 등 토큰 및 세션과 관련된 새로운 오류 코드를 추가하여, 세션이 유효하지 않거나 토큰이 없을 경우 적절한 예외 처리를 합니다.

4. **Redis 서비스 기능 확장**:
   - Redis 해시 데이터를 조회, 저장, 삭제하는 메서드 추가.
   - Redis에서 데이터 변환 시 발생하는 오류를 처리하는 `REDIS_CAST_ERROR` 예외를 추가했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없음

### 테스트
- [ ] 테스트 코드 작성 완료
- [ ] API 테스트 완료