### PR TITLE
hotfix: resolveTokenFromCookie 메서드에서 쿠키 파싱 로직 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
@@ -93,11 +93,11 @@ public class StompPreHandler implements ChannelInterceptor {
     private String resolveTokenFromCookie(StompHeaderAccessor accessor) {
         String cookieHeader = accessor.getFirstNativeHeader("Cookie");
         if (cookieHeader != null) {
-            for (String cookie : cookieHeader.split(";")) {
-                String[] cookiePair = cookie.split("=");
-                if (cookiePair.length == 2 && "accessToken".equals(cookiePair[0].trim())) {
-                    log.info("accessToken found in cookies: {}", cookiePair[1].trim());
-                    return cookiePair[1].trim();
+            String[] cookies = cookieHeader.split(";");
+            for (String cookie : cookies) {
+                String trimmedCookie = cookie.trim();
+                if (trimmedCookie.startsWith("accessToken=")) {
+                    return trimmedCookie.substring("accessToken=".length());
                 }
             }
         }


### PR DESCRIPTION


### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 토큰 파싱 오류

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 배열 인덱스 검사 없이 startsWith로 "accessToken" 쿠키 파싱 로직을 개선했습니다.
- 불필요한 로깅을 제거하여 코드 간결성을 높였습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 