### PR TITLE
feat: WebSocket 연결 시 쿠키 처리 로직 추가 및 인터셉터 도입

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/config/WebSocketConfig.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package connectripbe.connectrip_be.chat.config;
 
+import connectripbe.connectrip_be.chat.config.handler.CustomHandshakeInterceptor;
 import connectripbe.connectrip_be.chat.config.handler.StompPreHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,7 +26,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 클라이언트가 WebSocket에 연결할 수 있는 엔드포인트를 등록.
         registry.addEndpoint("/ws/init")  // 클라이언트가 "/ws" 엔드포인트로 WebSocket 연결을 시도할 수 있도록 설정.
-                .setAllowedOrigins(allowedOrigins)// 허용할 도메인을 설정.
+                //.setAllowedOrigins(allowedOrigins)// 허용할 도메인을 설정.
+                .setAllowedOriginPatterns("*") // CORS 요청을 허용.
+                .addInterceptors(new CustomHandshakeInterceptor())
                 .withSockJS();
     }
 

--- a/src/main/java/connectripbe/connectrip_be/chat/config/handler/CustomHandshakeInterceptor.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/handler/CustomHandshakeInterceptor.java
@@ -1,0 +1,29 @@
+package connectripbe.connectrip_be.chat.config.handler;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+@Slf4j
+public class CustomHandshakeInterceptor implements HandshakeInterceptor {
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+
+        String cookies = request.getHeaders().getFirst("Cookie");
+        log.info("cookie: {}", cookies);
+        if (cookies != null) {
+            // 쿠키를 세션이나 속성에 저장
+            attributes.put("cookie", cookies);
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
@@ -62,11 +62,11 @@ public class StompPreHandler implements ChannelInterceptor {
             throw new GlobalException(ErrorCode.INVALID_TOKEN);
         }
 
-        Long userId = jwtProvider.getMemberIdFromToken(accessToken);
+        Long memberId = jwtProvider.getMemberIdFromToken(accessToken);
         UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(userId, null, null);
+                new UsernamePasswordAuthenticationToken(memberId, null, null);
         accessor.setUser(authenticationToken);
-        log.info("User {} connected via WebSocket", userId);
+        log.info("User {} connected via WebSocket", memberId);
     }
 
     private void handleSubscribe(StompHeaderAccessor accessor) {


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] STOMP로 통신하여 웹소켓 요청헤더를 못 읽는 문제
- [ ] WebSocket 연결 시 클라이언트가 전송하는 쿠키를 인터셉트

### ✨ 이 PR에서 핵심적으로 변경된 사항
- `CustomHandshakeInterceptor`를 통해 WebSocket 연결 시 쿠키 정보를 세션 속성에 저장하고, 이후 쿠키를 기반으로 JWT 토큰을 추출하는 방식으로 변경.
- `StompPreHandler`에서 쿠키를 세션 속성으로부터 읽어와 토큰을 추출하고, 유효성을 검사하여 WebSocket 연결 및 메시지 구독 시 인증을 처리.
- 변수명을 개선하여 코드의 가독성을 향상시킴.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
- `.setAllowedOriginPatterns("*")`으로 CORS 설정을 개선하여 다양한 도메인에서의 접근을 허용.
- `resolveTokenFromCookie` 메서드에서 더 간결한 쿠키 파싱 로직을 적용.
