### PR TITLE
feat: 채팅방 참여자 리뷰 작성 가능 여부 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomMemberResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomMemberResponse.java
@@ -11,16 +11,19 @@ public record ChatRoomMemberResponse(
         Long memberId,
         String memberNickname,
         String memberProfileImage,
-        String memberChatRoomStatus
+        String memberChatRoomStatus,
+        boolean canWriteReview
 ) {
 
-    public static ChatRoomMemberResponse fromEntity(ChatRoomMemberEntity chatRoomMember) {
+    public static ChatRoomMemberResponse fromEntity(ChatRoomMemberEntity chatRoomMember
+            , boolean canWriteReview) {
         return ChatRoomMemberResponse.builder()
                 .chatRoomId(chatRoomMember.getChatRoom().getId())
                 .memberId(chatRoomMember.getMember().getId())
                 .memberNickname(chatRoomMember.getMember().getNickname())
                 .memberProfileImage(chatRoomMember.getMember().getProfileImagePath())
                 .memberChatRoomStatus(chatRoomMember.getStatus().toString())
+                .canWriteReview(canWriteReview)
                 .build();
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
@@ -9,7 +9,7 @@ public interface ChatRoomService {
 
     List<ChatRoomListResponse> getChatRoomList(Long memberId);
 
-    List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId);
+    List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId, Long memberId);
 
     void createChatRoom(Long postId, Long memberId);
 

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
@@ -32,9 +32,10 @@ public class ChatRoomController {
     // 해당 채팅방 참여자 목록 조회
     @GetMapping("/{chatRoomId}/members")
     public ResponseEntity<?> getChatRoomMembers(
-            @PathVariable Long chatRoomId
+            @PathVariable Long chatRoomId,
+            @AuthenticationPrincipal Long memberId
     ) {
-        return ResponseEntity.ok(chatRoomService.getChatRoomMembers(chatRoomId));
+        return ResponseEntity.ok(chatRoomService.getChatRoomMembers(chatRoomId, memberId));
     }
 
     // 해당 채팅방 나가기

--- a/src/main/java/connectripbe/connectrip_be/review/repository/AccompanyReviewRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/review/repository/AccompanyReviewRepository.java
@@ -23,4 +23,6 @@ public interface AccompanyReviewRepository extends JpaRepository<AccompanyReview
 
     // 특정 유저가 받은 리뷰의 개수 가져오기
     int countByTargetId(Long memberId);
+    
+    List<Long> findAllTargetIdsByReviewerIdAndChatRoomId(Long reviewerId, Long chatRoomId);
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ]  채팅방 참여자에 대해 현재 사용자가 리뷰를 작성할 수 있는지 여부를 확인하는 기능을 추가

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- **ChatRoomMemberResponse**에 `canWriteReview` 필드를 추가하여, 각 참여자에 대해 리뷰 작성 가능 여부를 포함.
- **ChatRoomService** 및 **ChatRoomServiceImpl**에서 참여자 목록을 조회할 때, 현재 사용자가 이미 리뷰를 작성했는지 확인하여 응답에 반영.
- 리뷰 여부를 확인하기 위해 **AccompanyReviewRepository**에 `findAllTargetIdsByReviewerIdAndChatRoomId` 메서드 추가.
- **ChatRoomController**에서 채팅방 참여자 목록 조회 시, 로그인한 사용자의 ID를 기반으로 리뷰 작성 가능 여부를 반환.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
- **ChatRoomServiceImpl** 내부에 참여자가 이미 리뷰를 작성했는지 판단하는 로직 추가.
- `chatRoomMemberResponse` 메서드를 통해 각 참여자에 대해 리뷰 작성 가능 여부를 계산하여 응답에 포함.