### PR TITLE
refactor: Redis 해시 데이터 처리 로직 개선 및 리스트 저장 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
@@ -99,7 +99,7 @@ public class StompPreHandler implements ChannelInterceptor {
                         + " memberID {}, chatRoomId: {}, sessionID: {}",
                 sessionDto.memberId(), sessionDto.chatRoomId()
                 , sessionId);
-        chatSessionService.removeUserSession(sessionId);
+        chatSessionService.removeUserSession(sessionId, sessionDto.chatRoomId());
     }
 
     // 쿠키에서 accessToken 추출

--- a/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/handler/StompPreHandler.java
@@ -99,7 +99,7 @@ public class StompPreHandler implements ChannelInterceptor {
                         + " memberID {}, chatRoomId: {}, sessionID: {}",
                 sessionDto.memberId(), sessionDto.chatRoomId()
                 , sessionId);
-        chatSessionService.removeUserSession(sessionId, sessionDto.chatRoomId());
+        chatSessionService.removeUserSession(sessionId, sessionDto.chatRoomId(), sessionDto.memberId());
     }
 
     // 쿠키에서 accessToken 추출

--- a/src/main/java/connectripbe/connectrip_be/chat/config/service/ChatSessionService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/service/ChatSessionService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class ChatSessionService {
 
     private static final String CHAT_ROOM_KEY_PREFIX = "chat_room_session: ";
+    private static final String CHAT_ROOM_LIST_KEY_PREFIX = "chat_room_list: ";
 
 
     private final RedisService redisService;
@@ -33,6 +34,7 @@ public class ChatSessionService {
 
         ChatRoomSessionDto sessionDto = new ChatRoomSessionDto(chatRoomId, memberId);
         redisService.setClassData(CHAT_ROOM_KEY_PREFIX + sessionId, sessionDto);
+        redisService.setListData(CHAT_ROOM_LIST_KEY_PREFIX + chatRoomId, sessionId);
     }
 
     // 세션 삭제 로직

--- a/src/main/java/connectripbe/connectrip_be/chat/config/service/ChatSessionService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/service/ChatSessionService.java
@@ -38,9 +38,9 @@ public class ChatSessionService {
     }
 
     // 세션 삭제 로직
-    public void removeUserSession(String sessionId, Long chatRoomId) {
+    public void removeUserSession(String sessionId, Long chatRoomId, Long memberId) {
         redisService.deleteData(CHAT_ROOM_KEY_PREFIX + sessionId);
-        redisService.deleteListData(CHAT_ROOM_LIST_KEY_PREFIX + chatRoomId, sessionId);
+        redisService.deleteListData(CHAT_ROOM_LIST_KEY_PREFIX + chatRoomId, memberId);
     }
 
     // 세션 조회 로직

--- a/src/main/java/connectripbe/connectrip_be/chat/config/service/ChatSessionService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/config/service/ChatSessionService.java
@@ -34,12 +34,13 @@ public class ChatSessionService {
 
         ChatRoomSessionDto sessionDto = new ChatRoomSessionDto(chatRoomId, memberId);
         redisService.setClassData(CHAT_ROOM_KEY_PREFIX + sessionId, sessionDto);
-        redisService.setListData(CHAT_ROOM_LIST_KEY_PREFIX + chatRoomId, sessionId);
+        redisService.setListData(CHAT_ROOM_LIST_KEY_PREFIX + chatRoomId, memberId);
     }
 
     // 세션 삭제 로직
-    public void removeUserSession(String sessionId) {
+    public void removeUserSession(String sessionId, Long chatRoomId) {
         redisService.deleteData(CHAT_ROOM_KEY_PREFIX + sessionId);
+        redisService.deleteListData(CHAT_ROOM_LIST_KEY_PREFIX + chatRoomId, sessionId);
     }
 
     // 세션 조회 로직

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
@@ -5,6 +5,7 @@ import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -26,6 +27,11 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMemberEn
 
     Optional<ChatRoomMemberEntity> findFirstByChatRoom_IdAndStatusOrderByCreatedAt(Long chatRoomId,
                                                                                    ChatRoomMemberStatus chatRoomMemberStatus);
+
+    @Query("SELECT m.id FROM chat_room_member crm "
+            + "JOIN crm.member m"
+            + " WHERE crm.chatRoom.id = :chatRoomId and crm.status = 'ACTIVE'")
+    List<Long> findMemberIdsByChatRoomId(Long chatRoomId);
 
 
     boolean existsByChatRoomIdAndMemberId(Long chatRoomId, Long memberId);

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -57,7 +57,6 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                         .build();
 
         ChatMessage saved = chatMessageRepository.save(chatMessage);
-        log.info("ChatMessage saved : {}", saved.getSenderId());
 
         ChatRoomEntity chatRoom = chatRoomRepository.findById(saved.getChatRoomId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
@@ -65,6 +64,9 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         // 채팅방 테이블에 채팅 마지막 내용과 마지막 시간 업데이트
         chatRoom.updateLastChatMessage(saved.getContent(), saved.getCreatedAt());
         chatRoomRepository.save(chatRoom);
+
+        // 채팅방에 입장하지 않은 사람들에게 알림 발송
+        sendMessageToNotification(chatRoomId, ChatMessageResponse.fromEntity(saved));
 
         return ChatMessageResponse.fromEntity(saved);
     }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -95,4 +95,5 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                     log.info("발송 성공: {}", memberId);
                 });
     }
+
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -6,6 +6,7 @@ import connectripbe.connectrip_be.chat.entity.ChatMessage;
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 import connectripbe.connectrip_be.chat.entity.type.MessageType;
 import connectripbe.connectrip_be.chat.repository.ChatMessageRepository;
+import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
 import connectripbe.connectrip_be.chat.repository.ChatRoomRepository;
 import connectripbe.connectrip_be.chat.service.ChatMessageService;
 import connectripbe.connectrip_be.global.exception.GlobalException;
@@ -24,6 +25,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final MemberJpaRepository memberJpaRepository;
 
     @Override

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -11,11 +11,13 @@ import connectripbe.connectrip_be.chat.repository.ChatRoomRepository;
 import connectripbe.connectrip_be.chat.service.ChatMessageService;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
+import connectripbe.connectrip_be.global.service.RedisService;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,10 +25,16 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class ChatMessageServiceImpl implements ChatMessageService {
 
+    private static final String CHAT_ROOM_KEY_PREFIX = "chat_room_session: ";
+    private static final String CHAT_ROOM_LIST_KEY_PREFIX = "chat_room_list: ";
+
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final MemberJpaRepository memberJpaRepository;
+    private final RedisService redisService;
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
 
     @Override
     public ChatMessageResponse saveMessage(ChatMessageRequest request, Long chatRoomId, Long memberId) {
@@ -68,5 +76,23 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         return chatMessages.stream()
                 .map(ChatMessageResponse::fromEntity)
                 .toList();
+    }
+
+    private void sendMessageToNotification(Long chatRoomId, ChatMessageResponse message) {
+        // 채팅방에 입장한 사용자 세션 리스트 조회
+        List<Object> activeSessionIds = redisService.getListData(CHAT_ROOM_LIST_KEY_PREFIX + chatRoomId);
+
+        // 채팅방 회원 리스트
+        List<Long> memberIds = chatRoomMemberRepository.findMemberIdsByChatRoomId(chatRoomId);
+
+        // 채팅방 회원 리스트 중 채팅방에 입장하지 않은 사람들에게 알림 발송
+        memberIds.stream()
+                .filter(memberId -> !activeSessionIds.contains(memberId))
+                .forEach(memberId -> {
+                    // 알림 발송
+                    simpMessagingTemplate.convertAndSend("/sub/member/notification/" + memberId, message);
+                    log.info("발송 성공: {}", memberId);
+                });
+
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -82,6 +82,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     private void sendMessageToNotification(Long chatRoomId, ChatMessageResponse message) {
         // 채팅방에 입장한 사용자 세션 리스트 조회
         List<Object> activeSessionIds = redisService.getListData(CHAT_ROOM_LIST_KEY_PREFIX + chatRoomId);
+        log.info("activeSessionIds: {}", activeSessionIds);
 
         // 채팅방 회원 리스트
         List<Long> memberIds = chatRoomMemberRepository.findMemberIdsByChatRoomId(chatRoomId);

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -94,6 +94,5 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                     simpMessagingTemplate.convertAndSend("/sub/member/notification/" + memberId, message);
                     log.info("발송 성공: {}", memberId);
                 });
-
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class ChatMessageServiceImpl implements ChatMessageService {
 
-    private static final String CHAT_ROOM_KEY_PREFIX = "chat_room_session: ";
     private static final String CHAT_ROOM_LIST_KEY_PREFIX = "chat_room_list: ";
 
     private final ChatMessageRepository chatMessageRepository;

--- a/src/main/java/connectripbe/connectrip_be/global/service/RedisService.java
+++ b/src/main/java/connectripbe/connectrip_be/global/service/RedisService.java
@@ -73,14 +73,6 @@ public class RedisService {
         }
     }
 
-    // 해시 값을 Redis 에서 조회 (명확한 반환 타입을 받기 위해 Class<T> 사용)
-    public <T> T getChatRoomHashKey(String hashKey, String key, Class<T> clazz) {
-        Object value = redisTemplate.opsForHash().get(hashKey, key);
-        if (clazz.isInstance(value)) {
-            return clazz.cast(value);
-        }
-        throw new GlobalException(ErrorCode.REDIS_CAST_ERROR);
-    }
 
     public <T> T getClassData(String key, Class<T> elementClass) {
         try {
@@ -109,21 +101,13 @@ public class RedisService {
         }
     }
 
-
-    // Redis 에 해시 값 저장
-    public void updateToHash(String hashKey, String key, Object value) {
+    // 리스트로 저장
+    public void setListData(String key, Object data) {
         try {
-            ObjectMapper mapper = new ObjectMapper();
-            String jsonData = mapper.writeValueAsString(value);
-            redisTemplate.opsForHash().put(hashKey, key, jsonData);
-
+            redisTemplate.opsForList().rightPush(key, data);
+            log.info("Redis List Data : {}", data);
         } catch (Exception e) {
-            log.error("Error occurred while updating hash : {}", e.getMessage());
+            log.error("Redis setListData Error : {}", e.getMessage());
         }
-    }
-
-    // Redis 에서 해시 값 삭제
-    public void deleteHashKey(String hashKey, String key) {
-        redisTemplate.opsForHash().delete(hashKey, key);
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/global/service/RedisService.java
+++ b/src/main/java/connectripbe/connectrip_be/global/service/RedisService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -76,9 +78,7 @@ public class RedisService {
 
     public <T> T getClassData(String key, Class<T> elementClass) {
         try {
-            log.info("Redis Key : {}", key);
             String jsonResult = (String) redisTemplate.opsForValue().get(key);
-            log.info("Redis Data : {}", jsonResult);
             if (StringUtils.isEmpty(jsonResult)) {
                 throw new GlobalException(ErrorCode.REDIS_GET_ERROR);
             } else {
@@ -105,9 +105,25 @@ public class RedisService {
     public void setListData(String key, Object data) {
         try {
             redisTemplate.opsForList().rightPush(key, data);
-            log.info("Redis List Data : {}", data);
         } catch (Exception e) {
             log.error("Redis setListData Error : {}", e.getMessage());
+        }
+    }
+
+    public void deleteListData(String key, Object data) {
+        try {
+            redisTemplate.opsForList().remove(key, 1, data);
+        } catch (Exception e) {
+            log.error("Redis deleteListData Error : {}", e.getMessage());
+        }
+    }
+
+    public List<Object> getListData(String key) {
+        try {
+            return redisTemplate.opsForList().range(key, 0, -1);
+        } catch (Exception e) {
+            log.error("Error fetching Redis List Data: {}", e.getMessage());
+            return Collections.emptyList();
         }
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/review/repository/AccompanyReviewRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/review/repository/AccompanyReviewRepository.java
@@ -23,6 +23,8 @@ public interface AccompanyReviewRepository extends JpaRepository<AccompanyReview
 
     // 특정 유저가 받은 리뷰의 개수 가져오기
     int countByTargetId(Long memberId);
-    
-    List<Long> findAllTargetIdsByReviewerIdAndChatRoomId(Long reviewerId, Long chatRoomId);
+
+    @Query("SELECT r.target FROM AccompanyReviewEntity r WHERE r.reviewer = :reviewerId AND r.chatRoom = :chatRoomId")
+    List<Long> findAllTargetIdsByReviewerIdAndChatRoomId(@Param("reviewerId") Long reviewerId,
+                                                         @Param("chatRoomId") Long chatRoomId);
 }


### PR DESCRIPTION
- 불필요한 해시 데이터 조회, 저장, 삭제 메서드 제거하여 코드 간소화.
- Redis에 리스트 형태로 데이터를 저장하는 기능 추가.
- ChatSessionService에서 세션 데이터를 리스트로 저장하도록 개선.
- ChatMessageServiceImpl에 채팅방 멤버 관련 로직 추가 준비.

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
-

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 