### PR TITLE
 feat: 채팅방 알림 기능 및 메시지 제목 길이 제한 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
@@ -13,6 +13,7 @@ public record ChatMessageResponse(
         MessageType type,
         Long chatRoomId,
         Long senderId,
+        String chatRoomTitle,
         String senderNickname,
         String senderProfileImage,
         String content,
@@ -31,6 +32,28 @@ public record ChatMessageResponse(
                 .senderNickname(chatMessage.getSenderNickname())
                 .senderProfileImage(chatMessage.getSenderProfileImage())
                 .content(chatMessage.getContent())
+                .infoFlag(chatMessage.isInfoFlag())
+                .createdAt(formatToUTC(chatMessage.getCreatedAt()))
+                .build();
+    }
+
+    public static ChatMessageResponse notificationFromEntity(ChatMessage chatMessage, String title) {
+        if (title.length() > 15) {
+            title = title.substring(0, 15);
+        }
+        String content = chatMessage.getContent();
+        if (content.length() > 20) {
+            content = content.substring(0, 20) + "...";
+        }
+        return ChatMessageResponse.builder()
+                .id(chatMessage.getId())
+                .type(chatMessage.getType())
+                .chatRoomId(chatMessage.getChatRoomId())
+                .senderId(chatMessage.getSenderId())
+                .chatRoomTitle(title)
+                .senderNickname(chatMessage.getSenderNickname())
+                .senderProfileImage(chatMessage.getSenderProfileImage())
+                .content(content)
                 .infoFlag(chatMessage.isInfoFlag())
                 .createdAt(formatToUTC(chatMessage.getCreatedAt()))
                 .build();

--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
@@ -43,7 +43,7 @@ public record ChatMessageResponse(
         }
         String content = chatMessage.getContent();
         if (content.length() > 20) {
-            content = content.substring(0, 20) + "...";
+            content = content.substring(0, 20);
         }
         return ChatMessageResponse.builder()
                 .id(chatMessage.getId())

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
@@ -14,6 +14,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> 
 
 
     @Query("select cr from chat_room cr "
-            + "join fetch cr.accompanyPost where cr.id =: chatRoomId")
+            + "join fetch cr.accompanyPost where cr.id = :chatRoomId")
     Optional<ChatRoomEntity> findByIdWithPost(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
@@ -4,6 +4,7 @@ import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,5 +15,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> 
 
     @Query("select cr from chat_room cr "
             + "join fetch cr.accompanyPost where cr.id =: chatRoomId")
-    Optional<ChatRoomEntity> findByIdWithPost(Long chatRoomId);
+    Optional<ChatRoomEntity> findByIdWithPost(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomRepository.java
@@ -3,10 +3,16 @@ package connectripbe.connectrip_be.chat.repository;
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
 
     Optional<ChatRoomEntity> findByAccompanyPost_Id(long id);
+
+
+    @Query("select cr from chat_room cr "
+            + "join fetch cr.accompanyPost where cr.id =: chatRoomId")
+    Optional<ChatRoomEntity> findByIdWithPost(Long chatRoomId);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -57,15 +57,18 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
         ChatMessage saved = chatMessageRepository.save(chatMessage);
 
-        ChatRoomEntity chatRoom = chatRoomRepository.findById(saved.getChatRoomId())
+        ChatRoomEntity chatRoom = chatRoomRepository.findByIdWithPost(saved.getChatRoomId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 채팅방 테이블에 채팅 마지막 내용과 마지막 시간 업데이트
         chatRoom.updateLastChatMessage(saved.getContent(), saved.getCreatedAt());
         chatRoomRepository.save(chatRoom);
 
+        String title = chatRoom.getAccompanyPost().getTitle();
+
         // 채팅방에 입장하지 않은 사람들에게 알림 발송
-        sendMessageToNotification(chatRoomId, ChatMessageResponse.fromEntity(saved));
+        sendMessageToNotification(chatRoomId, ChatMessageResponse.notificationFromEntity(saved, title));
+        log.info("리스폰스 {}", ChatMessageResponse.notificationFromEntity(saved, title));
 
         return ChatMessageResponse.fromEntity(saved);
     }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -87,9 +87,14 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         // 채팅방 회원 리스트
         List<Long> memberIds = chatRoomMemberRepository.findMemberIdsByChatRoomId(chatRoomId);
 
+        // 세션 ID를 Long 타입으로 변환
+        List<Long> activeMemberIds = activeSessionIds.stream()
+                .map(sessionId -> Long.valueOf(sessionId.toString()))
+                .toList();
+
         // 채팅방 회원 리스트 중 채팅방에 입장하지 않은 사람들에게 알림 발송
         memberIds.stream()
-                .filter(memberId -> !activeSessionIds.contains(memberId))
+                .filter(memberId -> !activeMemberIds.contains(memberId))
                 .forEach(memberId -> {
                     // 알림 발송
                     simpMessagingTemplate.convertAndSend("/sub/member/notification/" + memberId, message);

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -57,7 +57,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
         ChatMessage saved = chatMessageRepository.save(chatMessage);
 
-        ChatRoomEntity chatRoom = chatRoomRepository.findByIdWithPost(saved.getChatRoomId())
+        ChatRoomEntity chatRoom = chatRoomRepository.findByIdWithPost(chatRoomId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 채팅방 테이블에 채팅 마지막 내용과 마지막 시간 업데이트


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- 채팅방에 입장하지 않은 사용자들에게 메시지 알림을 발송하는 기능을 추가
- 알림에서 메시지와 제목의 길이를 제한

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->

1. **ChatMessageResponse 클래스 수정**:
   - `notificationFromEntity` 메서드를 추가하여, 알림 발송 시 제목과 메시지 내용을 제한된 길이로 반환.
   - 제목은 최대 15자, 메시지는 최대 20자로 잘려서 알림 메시지에 포함됩니다.
   
2. **ChatRoomRepository 수정**:
   - `findByIdWithPost` 메서드를 추가하여, 채팅방과 관련된 게시물 정보를 동시에 조회할 수 있도록 JPA 쿼리를 수정.

3. **ChatMessageServiceImpl 수정**:
   - 메시지 저장 후, 채팅방의 마지막 메시지 및 시간을 업데이트.
   - 알림 발송 로직에서 `notificationFromEntity` 메서드를 활용하여 메시지를 제한된 길이로 발송.
   - 현재 채팅방에 입장하지 않은 사용자에게만 알림을 발송하도록 수정.


