### PR TITLE
feat: 마지막 읽은 메시지 ID 업데이트 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
@@ -3,6 +3,7 @@ package connectripbe.connectrip_be.chat.entity;
 import connectripbe.connectrip_be.chat.entity.type.ChatRoomType;
 import connectripbe.connectrip_be.global.entity.BaseEntity;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -45,6 +46,10 @@ public class ChatRoomEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ChatRoomType chatRoomType;
 
+    @Builder.Default
+    @Column
+    private String lastReadMessageId = null;
+
     private String lastChatMessage;
 
     // 마지막 채팅 시간. 정렬을 위해 기본적으로 CreatedAt 값을 사용하고, 채팅이 발생할 때마다 업데이트
@@ -78,9 +83,10 @@ public class ChatRoomEntity extends BaseEntity {
     }
 
     //마지막 채팅 메시지 및 시간 업데이트 메서드
-    public void updateLastChatMessage(String message, LocalDateTime time) {
+    public void updateLastChatMessage(String message, LocalDateTime time, String lastReadMessageId) {
         this.lastChatMessage = message;
         this.lastChatTime = time;
+        this.lastReadMessageId = lastReadMessageId;
     }
 
 

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -61,7 +61,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                 .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 채팅방 테이블에 채팅 마지막 내용과 마지막 시간 업데이트
-        chatRoom.updateLastChatMessage(saved.getContent(), saved.getCreatedAt());
+        chatRoom.updateLastChatMessage(saved.getContent(), saved.getCreatedAt(), saved.getId());
         chatRoomRepository.save(chatRoom);
 
         String title = chatRoom.getAccompanyPost().getTitle();


### PR DESCRIPTION
### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- ChatRoomEntity에 lastReadMessageId 필드를 추가했습니다.
- updateLastChatMessage 메서드를 수정하여 마지막 읽은 메시지 ID를 업데이트하도록 했습니다.
- ChatMessageServiceImpl에서 저장 시 마지막 메시지 ID도 함께 업데이트합니다.
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 