### PR TITLE
 feat: 채팅방 안 읽은 메시지 여부 기능 추가 및 메시지 업데이트 로직 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
@@ -1,12 +1,10 @@
 package connectripbe.connectrip_be.chat.dto;
 
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
-
 import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-
 import lombok.Builder;
 
 @Builder
@@ -19,11 +17,12 @@ public record ChatRoomListResponse(
         String endDate,
         String lastChatMessage,
         String lastChatMessageTime,
-        int memberNumber
+        int memberNumber,
+        boolean hasUnreadMessages
 ) {
 
 
-    public static ChatRoomListResponse fromEntity(ChatRoomEntity chatRoom) {
+    public static ChatRoomListResponse fromEntity(ChatRoomEntity chatRoom, boolean hasUnreadMessages) {
         // 마지막 채팅 시간이 없을 경우 생성 시간으로 대체
         LocalDateTime lastChatTime = chatRoom.getLastChatTime() != null
                 ? chatRoom.getLastChatTime()
@@ -44,6 +43,7 @@ public record ChatRoomListResponse(
                 .lastChatMessage(chatRoom.getLastChatMessage())
                 .lastChatMessageTime(formatToUTC(lastChatTime))
                 .memberNumber(activeMemberCnt)
+                .hasUnreadMessages(hasUnreadMessages)
                 .build();
     }
 

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
@@ -82,10 +82,9 @@ public class ChatRoomEntity extends BaseEntity {
     }
 
     //마지막 채팅 메시지 및 시간 업데이트 메서드
-    public void updateLastChatMessage(String message, LocalDateTime time, String lastReadMessageId) {
+    public void updateLastChatMessage(String message, LocalDateTime time) {
         this.lastChatMessage = message;
         this.lastChatTime = time;
-        this.lastReadMessageId = lastReadMessageId;
     }
 
 

--- a/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/entity/ChatRoomEntity.java
@@ -46,9 +46,8 @@ public class ChatRoomEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ChatRoomType chatRoomType;
 
-    @Builder.Default
     @Column
-    private String lastReadMessageId = null;
+    private String lastReadMessageId;
 
     private String lastChatMessage;
 

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatMessageRepository.java
@@ -12,4 +12,6 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
 
     Optional<ChatMessage> findTopByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
 
+    Optional<ChatMessage> findFirstByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
+
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -1,5 +1,6 @@
 package connectripbe.connectrip_be.chat.service.impl;
 
+import com.mongodb.WriteConcern;
 import connectripbe.connectrip_be.chat.dto.ChatMessageRequest;
 import connectripbe.connectrip_be.chat.dto.ChatMessageResponse;
 import connectripbe.connectrip_be.chat.entity.ChatMessage;
@@ -62,16 +63,18 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         ChatRoomEntity chatRoom = chatRoomRepository.findByIdWithPost(chatRoomId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
-        String title = chatRoom.getAccompanyPost().getTitle();
-
-        // 채팅방에 입장하지 않은 사람들에게 알림 발송
-        sendMessageToNotification(chatRoomId, ChatMessageResponse.notificationFromEntity(saved, title));
-        log.info("리스폰스 {}", ChatMessageResponse.notificationFromEntity(saved, title));
+        mongoTemplate.setWriteConcern(WriteConcern.ACKNOWLEDGED);
 
         log.info("ID: {}", saved.getId());
         // 채팅방 테이블에 채팅 마지막 내용과 마지막 시간 업데이트
         chatRoom.updateLastChatMessage(saved.getContent(), saved.getCreatedAt(), saved.getId());
         chatRoomRepository.save(chatRoom);
+
+        String title = chatRoom.getAccompanyPost().getTitle();
+
+        // 채팅방에 입장하지 않은 사람들에게 알림 발송
+        sendMessageToNotification(chatRoomId, ChatMessageResponse.notificationFromEntity(saved, title));
+        log.info("리스폰스 {}", ChatMessageResponse.notificationFromEntity(saved, title));
 
         return ChatMessageResponse.fromEntity(saved);
     }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -60,6 +60,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         ChatRoomEntity chatRoom = chatRoomRepository.findByIdWithPost(chatRoomId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
+        log.info("ID: {}", saved.getId());
         // 채팅방 테이블에 채팅 마지막 내용과 마지막 시간 업데이트
         chatRoom.updateLastChatMessage(saved.getContent(), saved.getCreatedAt(), saved.getId());
         chatRoomRepository.save(chatRoom);

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -1,6 +1,5 @@
 package connectripbe.connectrip_be.chat.service.impl;
 
-import com.mongodb.WriteConcern;
 import connectripbe.connectrip_be.chat.dto.ChatMessageRequest;
 import connectripbe.connectrip_be.chat.dto.ChatMessageResponse;
 import connectripbe.connectrip_be.chat.entity.ChatMessage;
@@ -63,11 +62,8 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         ChatRoomEntity chatRoom = chatRoomRepository.findByIdWithPost(chatRoomId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
-        mongoTemplate.setWriteConcern(WriteConcern.ACKNOWLEDGED);
-
-        log.info("ID: {}", saved.getId());
         // 채팅방 테이블에 채팅 마지막 내용과 마지막 시간 업데이트
-        chatRoom.updateLastChatMessage(saved.getContent(), saved.getCreatedAt(), saved.getId());
+        chatRoom.updateLastChatMessage(saved.getContent(), saved.getCreatedAt());
         chatRoomRepository.save(chatRoom);
 
         String title = chatRoom.getAccompanyPost().getTitle();


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
- 채팅방 목록에서 사용자가 읽지 않은 메시지가 있는지 여부를 확인할 수 있도록 기능을 추가

### ✨ 주요 변경 사항
1. **ChatRoomListResponse 수정**:
   - 채팅방 리스트 응답 객체에 `hasUnreadMessages` 필드를 추가하여, 해당 채팅방에 읽지 않은 메시지가 있는지 여부를 전달합니다.
   - `fromEntity` 메서드에 `hasUnreadMessages` 파라미터를 추가하여, 읽지 않은 메시지 상태를 반영한 응답을 생성합니다.

2. **ChatRoomEntity 수정**:
   - `lastReadMessageId` 필드를 제거하고, 마지막 메시지 업데이트 시 해당 필드를 더 이상 사용하지 않도록 수정했습니다.

3. **ChatMessageRepository 수정**:
   - `findFirstByChatRoomIdOrderByCreatedAtDesc` 메서드를 추가하여, 특정 채팅방에서 가장 최근에 작성된 메시지를 조회할 수 있도록 했습니다.

4. **ChatRoomServiceImpl 수정**:
   - 채팅방 목록 조회 시 각 채팅방에 대해 사용자가 읽지 않은 메시지가 있는지 확인하는 `hasUnreadMessage` 메서드를 추가했습니다.
   - `getChatRoomList` 메서드를 수정하여, 각 채팅방에 대해 읽지 않은 메시지 여부를 포함한 응답을 생성합니다.

5. **ChatMessageServiceImpl 수정**:
   - 메시지 저장 시 마지막 읽은 메시지 ID를 더 이상 업데이트하지 않도록 수정했습니다.

### 📌 참고 사항
- 메시지 업데이트 로직에서 `lastReadMessageId`를 더 이상 사용하지 않으므로 관련된 기존 필드와 로직은 제거되었습니다.