### PR TITLE
feat: 메시지 페이징 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatMessageService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatMessageService.java
@@ -9,4 +9,6 @@ public interface ChatMessageService {
     ChatMessageResponse saveMessage(ChatMessageRequest chatMessage, Long chatRoomId, Long memberId);
 
     List<ChatMessageResponse> getMessages(Long chatRoomId);
+
+    List<ChatMessageResponse> getMessagesAfterId(Long chatRoomId, String lastMessageId, int size);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
@@ -6,6 +6,7 @@ import connectripbe.connectrip_be.chat.service.ChatMessageService;
 import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -13,6 +14,7 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,6 +23,7 @@ public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;
     private final SimpMessagingTemplate simpMessagingTemplate;
+    private final MongoTemplate mongoTemplate;
 
     @MessageMapping("/chat/room/{chatRoomId}")
     public void sendMessage(@Payload ChatMessageRequest chatMessage,
@@ -32,7 +35,12 @@ public class ChatMessageController {
     }
 
     @GetMapping("/api/v1/chatRoom/{chatRoomId}/messages")
-    public ResponseEntity<List<ChatMessageResponse>> getChatRoomMessages(@PathVariable Long chatRoomId) {
-        return ResponseEntity.ok(chatMessageService.getMessages(chatRoomId));
+    public ResponseEntity<List<ChatMessageResponse>> getChatRoomMessages(
+            @PathVariable Long chatRoomId,
+            @RequestParam(required = false) String lastMessageId,
+            @RequestParam(defaultValue = "50") int size) {
+        return ResponseEntity.ok(chatMessageService.getMessagesAfterId(chatRoomId, lastMessageId, size));
     }
+
+
 }


### PR DESCRIPTION
- 채팅 메시지 조회 시 마지막 메시지 ID와 조회할 메시지 수를 파라미터로 받아오는 기능 추가
- MongoDB 쿼리로 페이징 처리하여 효율적인 메시지 조회 가능

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
1. **ChatMessageService**:
   - `getMessagesAfterId(Long chatRoomId, String lastMessageId, int size)` 메서드 추가: 주어진 `chatRoomId`에서 `lastMessageId` 이후의 메시지를 가져오는 기능을 추가했습니다. 페이징 처리를 위해 `size` 파라미터를 사용하여 가져올 메시지의 수를 제한할 수 있습니다.

2. **ChatMessageServiceImpl**:
   - MongoDB 쿼리를 사용해 메시지를 내림차순으로 정렬한 뒤, `lastMessageId` 이후의 메시지를 지정된 수만큼 조회하도록 구현했습니다. 
   - 조회된 메시지는 다시 시간 순서대로 정렬되어 반환됩니다.

3. **ChatMessageController**:
   - 새로운 API 엔드포인트 `/api/v1/chatRoom/{chatRoomId}/messages` 추가: 해당 엔드포인트를 통해 `chatRoomId`와 `lastMessageId`, `size` 파라미터로 메시지 목록을 요청할 수 있습니다. 
   - 기본적으로 최근 50개의 메시지를 가져오도록 설정되어 있으며, 필요에 따라 `lastMessageId`와 `size`를 통해 메시지 조회 범위를 조절할 수 있습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
