### PR TITLE
fix: 불필요한 NullPointerException 방지 코드 수정

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -117,7 +117,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         Query query = new Query();
         query.addCriteria(Criteria.where("chatRoomId").is(chatRoomId));
 
-        if (lastMessageId != null) {
+        if (!lastMessageId.equals("first")) {
             // 마지막 메시지 이후 데이터를 가져옴
             query.addCriteria(Criteria.where("_id").lt(new ObjectId(lastMessageId)));
         }

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
@@ -37,7 +37,7 @@ public class ChatMessageController {
     @GetMapping("/api/v1/chatRoom/{chatRoomId}/messages")
     public ResponseEntity<List<ChatMessageResponse>> getChatRoomMessages(
             @PathVariable Long chatRoomId,
-            @RequestParam(required = false) String lastMessageId,
+            @RequestParam String lastMessageId,
             @RequestParam(defaultValue = "50") int size) {
         return ResponseEntity.ok(chatMessageService.getMessagesAfterId(chatRoomId, lastMessageId, size));
     }


### PR DESCRIPTION
### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- lastMessageId 파라미터가 null인 경우를 처리하도록 수정했습니다.
- 메시지 검색 로직에서 "first"라는 기본값을 사용하여 안전성을 확보했습니다.
- 
### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 