### PR TITLE
refactor: 공통 시간 포맷팅 로직을 DateTimeUtils로 이동

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatMessageResponse.java
@@ -2,9 +2,7 @@ package connectripbe.connectrip_be.chat.dto;
 
 import connectripbe.connectrip_be.chat.entity.ChatMessage;
 import connectripbe.connectrip_be.chat.entity.type.MessageType;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
+import connectripbe.connectrip_be.global.util.time.DateTimeUtils;
 import lombok.Builder;
 
 @Builder
@@ -20,9 +18,6 @@ public record ChatMessageResponse(
         Boolean infoFlag,
         String createdAt
 ) {
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss'Z'");
-
     public static ChatMessageResponse fromEntity(ChatMessage chatMessage) {
         return ChatMessageResponse.builder()
                 .id(chatMessage.getId())
@@ -33,7 +28,7 @@ public record ChatMessageResponse(
                 .senderProfileImage(chatMessage.getSenderProfileImage())
                 .content(chatMessage.getContent())
                 .infoFlag(chatMessage.isInfoFlag())
-                .createdAt(formatToUTC(chatMessage.getCreatedAt()))
+                .createdAt(DateTimeUtils.formatUTC(chatMessage.getCreatedAt()))
                 .build();
     }
 
@@ -55,15 +50,8 @@ public record ChatMessageResponse(
                 .senderProfileImage(chatMessage.getSenderProfileImage())
                 .content(content)
                 .infoFlag(chatMessage.isInfoFlag())
-                .createdAt(formatToUTC(chatMessage.getCreatedAt()))
+                .createdAt(DateTimeUtils.formatUTC(chatMessage.getCreatedAt()))
                 .build();
     }
 
-    private static String formatToUTC(LocalDateTime dateTime) {
-        if (dateTime == null) {
-            return null;
-        }
-        return dateTime.atZone(ZoneId.systemDefault())
-                .format(UTC_FORMATTER);
-    }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatRoomListResponse.java
@@ -2,9 +2,8 @@ package connectripbe.connectrip_be.chat.dto;
 
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
+import connectripbe.connectrip_be.global.util.time.DateTimeUtils;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 
 @Builder
@@ -38,23 +37,13 @@ public record ChatRoomListResponse(
                 .accompanyPostId(chatRoom.getAccompanyPost().getId())
                 .accompanyPostTitle(chatRoom.getAccompanyPost().getTitle())
                 .accompanyArea(chatRoom.getAccompanyPost().getAccompanyArea())
-                .startDate(formatToUTC(chatRoom.getAccompanyPost().getStartDate()))
-                .endDate(formatToUTC(chatRoom.getAccompanyPost().getEndDate()))
+                .startDate(DateTimeUtils.formatUTC(chatRoom.getAccompanyPost().getStartDate()))
+                .endDate(DateTimeUtils.formatUTC(chatRoom.getAccompanyPost().getEndDate()))
                 .lastChatMessage(chatRoom.getLastChatMessage())
-                .lastChatMessageTime(formatToUTC(lastChatTime))
+                .lastChatMessageTime(DateTimeUtils.formatUTC(lastChatTime))
                 .memberNumber(activeMemberCnt)
                 .hasUnreadMessages(hasUnreadMessages)
                 .build();
     }
 
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss'Z'");
-
-    private static String formatToUTC(LocalDateTime dateTime) {
-        if (dateTime == null) {
-            return null;
-        }
-        return dateTime.atZone(ZoneId.systemDefault())
-                .format(UTC_FORMATTER);
-    }
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/ChatRoomMemberRepository.java
@@ -23,6 +23,8 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMemberEn
 
     Optional<ChatRoomMemberEntity> findByChatRoom_IdAndMember_Id(Long chatRoomId, Long memberId);
 
+    boolean existsByChatRoom_IdAndMember_Id(Long chatRoomId, Long memberId);
+
     Integer countByChatRoom_IdAndStatus(Long chatRoomId, ChatRoomMemberStatus chatRoomMemberStatus);
 
     Optional<ChatRoomMemberEntity> findFirstByChatRoom_IdAndStatusOrderByCreatedAt(Long chatRoomId,

--- a/src/main/java/connectripbe/connectrip_be/chat/repository/impl/CustomChatRoomMemberRepositoryImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/repository/impl/CustomChatRoomMemberRepositoryImpl.java
@@ -18,11 +18,8 @@ public class CustomChatRoomMemberRepositoryImpl implements CustomChatRoomMemberR
     private final JPAQueryFactory jpa;
 
     /**
-     *
-     * 주어진 이메일에 해당하는 사용자가 속한 채팅방 목록을 반환
-     * 채팅방 목록은 사용자가 참여 중인 방으로 제한되며,
-     * 삭제되었거나 사용자가 나간 방은 제외.
-     * 결과는 마지막 채팅 시간(lastChatTime)을 기준으로 내림차순 정렬됩니다.
+     * 주어진 이메일에 해당하는 사용자가 속한 채팅방 목록을 반환 채팅방 목록은 사용자가 참여 중인 방으로 제한되며, 삭제되었거나 사용자가 나간 방은 제외. 결과는 마지막 채팅 시간(lastChatTime)을
+     * 기준으로 내림차순 정렬됩니다.
      *
      * @param memberId 조회할 사용자의 아이디
      * @return 사용자가 속한 ChatRoomMemberEntity 의 리스트
@@ -43,4 +40,5 @@ public class CustomChatRoomMemberRepositoryImpl implements CustomChatRoomMemberR
                 .orderBy(chatRoom.lastChatTime.desc())
                 .fetch();
     }
+
 }

--- a/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/comment/dto/AccompanyCommentResponse.java
@@ -1,15 +1,12 @@
 package connectripbe.connectrip_be.comment.dto;
 
 import connectripbe.connectrip_be.comment.entity.AccompanyCommentEntity;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
+import connectripbe.connectrip_be.global.util.time.DateTimeUtils;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
 
 
 @Getter
@@ -39,21 +36,11 @@ public class AccompanyCommentResponse {
                 .memberNickname(comment.getMemberEntity().getNickname())
                 .memberProfileImage(comment.getMemberEntity().getProfileImagePath())
                 .content(comment.getContent())
-                .createdAt(formatToUTC(comment.getCreatedAt()))
-                .updatedAt(formatToUTC(comment.getUpdatedAt()))
-                .deletedAt(formatToUTC(comment.getDeletedAt()))
+                .createdAt(DateTimeUtils.formatUTC(comment.getCreatedAt()))
+                .updatedAt(DateTimeUtils.formatUTC(comment.getUpdatedAt()))
+                .deletedAt(DateTimeUtils.formatUTC(comment.getDeletedAt()))
                 .build();
     }
 
-    // UTC 형식으로 변환하는 메서드 추가
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-    private static String formatToUTC(LocalDateTime dateTime) {
-        if (dateTime == null) {
-            return null;
-        }
-        return dateTime.atZone(ZoneId.systemDefault())
-                .format(UTC_FORMATTER);
-    }
 }

--- a/src/main/java/connectripbe/connectrip_be/communitycomment/dto/CommunityCommentResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/communitycomment/dto/CommunityCommentResponse.java
@@ -1,9 +1,7 @@
 package connectripbe.connectrip_be.communitycomment.dto;
 
 import connectripbe.connectrip_be.communitycomment.entity.CommunityCommentEntity;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
+import connectripbe.connectrip_be.global.util.time.DateTimeUtils;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,21 +34,11 @@ public class CommunityCommentResponse {
                 .memberNickname(comment.getMemberEntity().getNickname())
                 .memberProfileImage(comment.getMemberEntity().getProfileImagePath())
                 .content(comment.getContent())
-                .createdAt(formatToUTC(comment.getCreatedAt()))
-                .updatedAt(formatToUTC(comment.getUpdatedAt()))
-                .deletedAt(formatToUTC(comment.getDeletedAt()))
+                .createdAt(DateTimeUtils.formatUTC(comment.getCreatedAt()))
+                .updatedAt(DateTimeUtils.formatUTC(comment.getUpdatedAt()))
+                .deletedAt(DateTimeUtils.formatUTC(comment.getDeletedAt()))
                 .build();
     }
 
-    // UTC 형식으로 변환하는 메서드 추가
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-    private static String formatToUTC(LocalDateTime dateTime) {
-        if (dateTime == null) {
-            return null;
-        }
-        return dateTime.atZone(ZoneId.systemDefault())
-                .format(UTC_FORMATTER);
-    }
 }

--- a/src/main/java/connectripbe/connectrip_be/global/util/time/DateTimeUtils.java
+++ b/src/main/java/connectripbe/connectrip_be/global/util/time/DateTimeUtils.java
@@ -1,6 +1,7 @@
 package connectripbe.connectrip_be.global.util.time;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import lombok.experimental.UtilityClass;
 
@@ -13,7 +14,7 @@ public class DateTimeUtils {
         if (dateTime == null) {
             return null;
         }
-        return dateTime.atZone(DateTimeUtils.UTC_FORMATTER.getZone())
+        return dateTime.atZone(ZoneId.systemDefault())
                 .format(DateTimeUtils.UTC_FORMATTER);
     }
 

--- a/src/main/java/connectripbe/connectrip_be/member/dto/ProfileDto.java
+++ b/src/main/java/connectripbe/connectrip_be/member/dto/ProfileDto.java
@@ -1,10 +1,8 @@
 package connectripbe.connectrip_be.member.dto;
 
+import connectripbe.connectrip_be.global.util.time.DateTimeUtils;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.review.dto.AccompanyReviewResponse;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,19 +36,9 @@ public class ProfileDto {
                 .recentReviews(recentReviews)
                 .description(member.getDescription())
                 .ageGroup(ageGroup)
-                .createdAt(formatToUTC(member.getCreatedAt()))
+                .createdAt(DateTimeUtils.formatUTC(member.getCreatedAt()))
                 .build();
     }
 
-    // UTC 형식으로 변환하는 메서드 추가
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-    private static String formatToUTC(LocalDateTime dateTime) {
-        if (dateTime == null) {
-            return null;
-        }
-        return dateTime.atZone(ZoneId.systemDefault())
-                .format(UTC_FORMATTER);
-    }
 }

--- a/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostListResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostListResponse.java
@@ -2,10 +2,8 @@ package connectripbe.connectrip_be.post.dto;
 
 import static org.springframework.util.StringUtils.truncate;
 
+import connectripbe.connectrip_be.global.util.time.DateTimeUtils;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 
 // todo-noah: 이름 변경, utc 분리
@@ -28,22 +26,14 @@ public record AccompanyPostListResponse(
                 .memberId(accompanyPost.getMemberEntity().getId())
                 .nickname(accompanyPost.getMemberEntity().getNickname())
                 .title(truncate(accompanyPost.getTitle(), 21))
-                .startDate(formatToUTC(accompanyPost.getStartDate()))
-                .endDate(formatToUTC(accompanyPost.getEndDate()))
+                .startDate(DateTimeUtils.formatUTC(accompanyPost.getStartDate()))
+                .endDate(DateTimeUtils.formatUTC(accompanyPost.getEndDate()))
                 .accompanyArea(accompanyPost.getAccompanyArea())
                 .content(truncate(accompanyPost.getContent(), 36))
-                .createdAt(formatToUTC(accompanyPost.getCreatedAt()))
+                .createdAt(DateTimeUtils.formatUTC(accompanyPost.getCreatedAt()))
                 .profileImagePath(accompanyPost.getMemberEntity().getProfileImagePath())
                 .build();
     }
 
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-    private static String formatToUTC(LocalDateTime dateTime) {
-        if (dateTime == null) {
-            return null;
-        }
-        return dateTime.atZone(ZoneId.systemDefault())
-                .format(UTC_FORMATTER);
-    }
 }

--- a/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/post/dto/AccompanyPostResponse.java
@@ -1,12 +1,9 @@
 package connectripbe.connectrip_be.post.dto;
 
 import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
+import connectripbe.connectrip_be.global.util.time.DateTimeUtils;
 import connectripbe.connectrip_be.post.entity.AccompanyPostEntity;
 import lombok.Builder;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 
 @Builder
 public record AccompanyPostResponse(
@@ -36,26 +33,17 @@ public record AccompanyPostResponse(
                 .nickname(accompanyPost.getMemberEntity().getNickname())
                 .profileImagePath(accompanyPost.getMemberEntity().getProfileImagePath())
                 .title(accompanyPost.getTitle())
-                .startDate(formatToUTC(accompanyPost.getStartDate()))
-                .endDate(formatToUTC(accompanyPost.getEndDate()))
+                .startDate(DateTimeUtils.formatUTC(accompanyPost.getStartDate()))
+                .endDate(DateTimeUtils.formatUTC(accompanyPost.getEndDate()))
                 .accompanyArea(accompanyPost.getAccompanyArea())
                 .customUrl(accompanyPost.getCustomUrl())
                 .urlQrPath(accompanyPost.getUrlQrPath())
                 .content(accompanyPost.getContent())
                 .status(status)
-                .createdAt(formatToUTC(accompanyPost.getCreatedAt()))
+                .createdAt(DateTimeUtils.formatUTC(accompanyPost.getCreatedAt()))
                 .build();
 
     }
 
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-    private static String formatToUTC(LocalDateTime dateTime) {
-        if (dateTime == null) {
-            return null;
-        }
-        return dateTime.atZone(ZoneId.systemDefault())
-                .format(UTC_FORMATTER);
-    }
 }

--- a/src/main/java/connectripbe/connectrip_be/review/dto/AccompanyReviewResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/review/dto/AccompanyReviewResponse.java
@@ -1,9 +1,7 @@
 package connectripbe.connectrip_be.review.dto;
 
+import connectripbe.connectrip_be.global.util.time.DateTimeUtils;
 import connectripbe.connectrip_be.review.entity.AccompanyReviewEntity;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,7 +18,6 @@ public class AccompanyReviewResponse {
     private int reviewCount; // 리뷰 개수 추가
     private String createdAt;
 
-    // 엔티티를 DTO로 변환하는 메서드
     public static AccompanyReviewResponse fromEntity(AccompanyReviewEntity review, int reviewCount) {
         return AccompanyReviewResponse.builder()
                 .reviewId(review.getId())
@@ -31,19 +28,10 @@ public class AccompanyReviewResponse {
                 .reviewerId(review.getReviewer().getId()) // 작성자 ID
                 .targetId(review.getTarget().getId()) // 대상자 ID
                 .reviewCount(reviewCount) // 리뷰 수 추가
-                .createdAt(formatToUTC(review.getCreatedAt())) // 작성일
+                .createdAt(DateTimeUtils.formatUTC(review.getCreatedAt())) // 작성일
                 .build();
     }
 
-    // UTC 형식으로 변환하는 메서드
-    private static final DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-    private static String formatToUTC(LocalDateTime dateTime) {
-        if (dateTime == null) {
-            return null;
-        }
-        return dateTime.atZone(ZoneId.systemDefault()) // 시스템 시간대 적용
-                .format(UTC_FORMATTER); // 형식에 맞춰 반환
-    }
 }
 


### PR DESCRIPTION
### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- 중복된 UTC 시간 포맷팅 코드를 DateTimeUtils로 통합하여 코드 가독성 및 유지보수성 향상.
- 각 DTO 클래스에서 시간 포맷팅 메소드 제거 및 DateTimeUtils 사용으로 대체.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-  없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 