### PR TITLE
fix: 채팅방 메시지 조회 시 인증된 사용자 확인 로직 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatMessageService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatMessageService.java
@@ -10,5 +10,5 @@ public interface ChatMessageService {
 
     List<ChatMessageResponse> getMessages(Long chatRoomId);
 
-    List<ChatMessageResponse> getMessagesAfterId(Long chatRoomId, String lastMessageId, int size);
+    List<ChatMessageResponse> getMessagesAfterId(Long memberId, Long chatRoomId, String lastMessageId, int size);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatMessageServiceImpl.java
@@ -101,7 +101,6 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         List<Long> activeMemberIds = activeSessionIds.stream()
                 .map(sessionId -> Long.valueOf(sessionId.toString()))
                 .toList();
-
         // 채팅방 회원 리스트 중 채팅방에 입장하지 않은 사람들에게 알림 발송
         memberIds.stream()
                 .filter(memberId -> !activeMemberIds.contains(memberId))
@@ -113,7 +112,14 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     }
 
     @Override
-    public List<ChatMessageResponse> getMessagesAfterId(Long chatRoomId, String lastMessageId, int size) {
+    public List<ChatMessageResponse> getMessagesAfterId(Long memberId, Long chatRoomId, String lastMessageId,
+                                                        int size) {
+
+        boolean exists = chatRoomMemberRepository.existsByChatRoom_IdAndMember_Id(chatRoomId, memberId);
+        if (!exists) {
+            throw new GlobalException(ErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND);
+        }
+
         Query query = new Query();
         query.addCriteria(Criteria.where("chatRoomId").is(chatRoomId));
 
@@ -131,6 +137,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                 .sorted(Comparator.comparing(ChatMessage::getCreatedAt))
                 .map(ChatMessageResponse::fromEntity)
                 .toList();
+
     }
 
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatMessageController.java
@@ -12,6 +12,7 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -36,10 +37,11 @@ public class ChatMessageController {
 
     @GetMapping("/api/v1/chatRoom/{chatRoomId}/messages")
     public ResponseEntity<List<ChatMessageResponse>> getChatRoomMessages(
+            @AuthenticationPrincipal Long memberId,
             @PathVariable Long chatRoomId,
             @RequestParam String lastMessageId,
             @RequestParam(defaultValue = "50") int size) {
-        return ResponseEntity.ok(chatMessageService.getMessagesAfterId(chatRoomId, lastMessageId, size));
+        return ResponseEntity.ok(chatMessageService.getMessagesAfterId(memberId, chatRoomId, lastMessageId, size));
     }
 
 


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 채팅방 메시지 조회 시 인증된 사용자가 해당 채팅방의 멤버인지 확인하는 로직이 없어서, 인증되지 않은 사용자가 메시지를 조회할 수 있는 문제

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 채팅방 메시지를 조회할 때, 해당 사용자가 해당 채팅방의 멤버인지 확인하는 로직을 추가했습니다.
- `ChatMessageService`와 `ChatMessageServiceImpl`에서 사용자 인증 로직을 추가했습니다.
- `ChatMessageController`에서 `@AuthenticationPrincipal`을 통해 인증된 사용자의 ID를 받아와 메시지 조회에 사용하도록 수정했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
- 없음

### 테스트
- [ ] 테스트 코드 작성 및 실행
- [ ] API 테스트