### PR TITLE
동행, 커뮤니티 댓글 기능 리팩토링

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/dto/AccompanyCommentRequest.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/dto/AccompanyCommentRequest.java
@@ -1,8 +1,5 @@
 package connectripbe.connectrip_be.accompany.comment.dto;
 
-import connectripbe.connectrip_be.accompany.comment.entity.AccompanyCommentEntity;
-import connectripbe.connectrip_be.accompany.post.entity.AccompanyPostEntity;
-import connectripbe.connectrip_be.member.entity.MemberEntity;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -24,12 +21,4 @@ public class AccompanyCommentRequest {
     @NotBlank(message = "내용은 필수입니다.")
     private String content;
 
-    // DTO를 AccompanyComment 엔티티로 변환하는 메서드
-    public AccompanyCommentEntity toEntity(AccompanyPostEntity post, MemberEntity member) {
-        return AccompanyCommentEntity.builder()
-                .accompanyPostEntity(post)
-                .memberEntity(member)
-                .content(this.content)
-                .build();
-    }
 }

--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/entity/AccompanyCommentEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/entity/AccompanyCommentEntity.java
@@ -17,7 +17,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "accompany_comment")
@@ -39,7 +38,6 @@ public class AccompanyCommentEntity extends BaseEntity {
     @JoinColumn(name = "accompany_post_id", nullable = false)
     private AccompanyPostEntity accompanyPostEntity;  // 동행 아이디 (외래키)
 
-    @Setter
     @Column(nullable = false, length = 256)
     private String content;  // 내용
 

--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/entity/AccompanyCommentEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/entity/AccompanyCommentEntity.java
@@ -41,5 +41,8 @@ public class AccompanyCommentEntity extends BaseEntity {
     @Column(nullable = false, length = 256)
     private String content;  // 내용
 
-    // 기존 생성자 제거 (빌더 패턴으로 대체됨)
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+
 }

--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/repository/AccompanyCommentRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/repository/AccompanyCommentRepository.java
@@ -9,8 +9,11 @@ public interface AccompanyCommentRepository extends JpaRepository<AccompanyComme
 
     Optional<AccompanyCommentEntity> findByIdAndDeletedAtIsNull(long id);
 
-    Optional<AccompanyCommentEntity> findByIdAndMemberEntity_IdAndDeletedAtIsNull(Long commentId, Long memberId);
-    
     // AccompanyPostEntity 의 ID로 삭제되지 않은 댓글 목록 조회
     List<AccompanyCommentEntity> findByAccompanyPostEntity_IdAndDeletedAtIsNull(Long postId);
+
+    boolean existsByIdAndMemberEntity_IdAndDeletedAtIsNull(Long commentId, Long memberId);
+
 }
+
+

--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/repository/AccompanyCommentRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/repository/AccompanyCommentRepository.java
@@ -9,6 +9,8 @@ public interface AccompanyCommentRepository extends JpaRepository<AccompanyComme
 
     Optional<AccompanyCommentEntity> findByIdAndDeletedAtIsNull(long id);
 
+    Optional<AccompanyCommentEntity> findByIdAndMemberEntity_IdAndDeletedAtIsNull(Long commentId, Long memberId);
+    
     // AccompanyPostEntity 의 ID로 삭제되지 않은 댓글 목록 조회
     List<AccompanyCommentEntity> findByAccompanyPostEntity_IdAndDeletedAtIsNull(Long postId);
 }

--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
@@ -69,9 +69,12 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     @Override
     @Transactional
     public AccompanyCommentResponse updateComment(Long memberId, Long commentId, AccompanyCommentRequest request) {
+        // 작성자가 맞는지 확인하며 댓글을 조회
         AccompanyCommentEntity comment = accompanyCommentRepository.findByIdAndMemberEntity_IdAndDeletedAtIsNull(
                         commentId, memberId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.WRITE_NOT_YOURSELF));
+
+        getComment(commentId);
 
         comment.updateContent(request.getContent());
 
@@ -79,6 +82,7 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
 
         return AccompanyCommentResponse.fromEntity(comment);
     }
+
 
     /**
      * 댓글을 삭제하는 메서드. 주어진 댓글 ID와 작성자 ID로 AccompanyCommentEntity를 조회한 후, 해당 댓글이 본인의 댓글인지 확인하고, 삭제 처리합니다.
@@ -92,6 +96,8 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
         AccompanyCommentEntity comment = accompanyCommentRepository.findByIdAndMemberEntity_IdAndDeletedAtIsNull(
                         commentId, memberId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.WRITE_NOT_YOURSELF));
+
+        getComment(commentId);
 
         comment.deleteEntity();
 

--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
@@ -42,8 +42,12 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     public AccompanyCommentResponse createComment(Long memberId, AccompanyCommentRequest request) {
         MemberEntity member = getMember(memberId);
         AccompanyPostEntity post = getPost(request.getPostId());
-
-        AccompanyCommentEntity comment = request.toEntity(post, member);
+        
+        AccompanyCommentEntity comment = AccompanyCommentEntity.builder()
+                .memberEntity(member)
+                .accompanyPostEntity(post)
+                .content(request.getContent())
+                .build();
 
         accompanyCommentRepository.save(comment);
 

--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
@@ -68,22 +68,22 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     @Override
     @Transactional
     public AccompanyCommentResponse updateComment(Long memberId, Long commentId, AccompanyCommentRequest request) {
-        // 댓글 엔티티 조회
-        AccompanyCommentEntity existingComment = getComment(commentId);
+        // 댓글 조회
+        AccompanyCommentEntity comment = getComment(commentId);
 
-        // 댓글 작성자와 요청한 사용자가 일치하는지 확인
-        validateCommentAuthor(memberId, existingComment);
+        // 권한 확인 (댓글 작성자와 요청자의 ID가 다른 경우 예외 발생)
+        if (!comment.getMemberEntity().getId().equals(memberId)) {
+            throw new GlobalException(ErrorCode.WRITE_NOT_YOURSELF);
+        }
 
-        // 새 댓글 엔티티 생성 (수정된 내용 반영)
-        AccompanyCommentEntity updatedComment = AccompanyCommentEntity.builder()
-                .id(existingComment.getId()) // 기존 ID 유지
-                .memberEntity(existingComment.getMemberEntity()) // 기존 사용자 정보 유지
-                .accompanyPostEntity(existingComment.getAccompanyPostEntity()) // 기존 게시글 정보 유지
-                .content(request.getContent()) // 새 내용 반영
-                .build();
+        // 댓글 내용 업데이트
+        comment.updateContent(request.getContent());
 
-        // 댓글 저장 및 응답 반환
-        return AccompanyCommentResponse.fromEntity(accompanyCommentRepository.save(updatedComment));
+        // 엔티티를 저장하여 업데이트 반영
+        accompanyCommentRepository.save(comment);
+
+        // 수정된 댓글 정보 반환
+        return AccompanyCommentResponse.fromEntity(comment);
     }
 
 

--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
@@ -29,12 +29,13 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
 
 
     /**
-     * 댓글을 생성하는 메서드. 사용자 이메일을 통해 MemberEntity를 조회하고, 게시물 ID를 통해 AccompanyPostEntity를 조회한 후 AccompanyCommentEntity를 생성하여
-     * 데이터베이스에 저장
+     * 댓글을 생성하는 메서드. 주어진 memberId를 통해 사용자 정보를 조회하고, 요청 정보에서 게시물 ID를 가져와 해당 게시물 정보를 조회한 후, AccompanyCommentRequest를 사용하여
+     * 새로운 AccompanyCommentEntity를 생성하고 데이터베이스에 저장합니다.
      *
      * @param memberId 댓글 작성자의 아이디
-     * @param request  댓글 생성 요청 정보 (게시물 ID, 댓글 내용 포함)
-     * @return 생성된 댓글의 정보를 담은 AccompanyCommentResponse 객체
+     * @param request  댓글 생성 요청 정보 (게시물 ID 및 댓글 내용 포함)
+     * @return 생성된 댓글 정보를 담고 있는 AccompanyCommentResponse 객체
+     * @throws GlobalException 사용자가 존재하지 않거나 게시물이 존재하지 않을 경우 예외 발생
      */
     @Override
     @RateLimit(capacity = 10, refillTokens = 10)
@@ -42,12 +43,7 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
         MemberEntity member = getMember(memberId);
         AccompanyPostEntity post = getPost(request.getPostId());
 
-        // 댓글 생성
-        AccompanyCommentEntity comment = AccompanyCommentEntity.builder()
-                .memberEntity(member)
-                .accompanyPostEntity(post)
-                .content(request.getContent())
-                .build();
+        AccompanyCommentEntity comment = request.toEntity(post, member);
 
         accompanyCommentRepository.save(comment);
 

--- a/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/comment/service/impl/AccompanyCommentServiceImpl.java
@@ -60,24 +60,32 @@ public class AccompanyCommentServiceImpl implements AccompanyCommentService {
     /**
      * 댓글을 수정하는 메서드. 주어진 댓글 ID를 통해 AccompanyCommentEntity를 조회하고, 수정 권한이 있는지 확인한 후 댓글 내용을 업데이트
      *
-     * @param memberId  수정하려는 사용자의 아이디
-     * @param request   댓글 수정 요청 정보 (수정된 댓글 내용 포함)
+     * @param memberId  댓글을 수정하려는 사용자의 아이디
      * @param commentId 수정할 댓글의 ID
-     * @return 수정된 댓글의 정보를 담은 AccompanyCommentResponse 객체
+     * @param request   댓글 수정 요청 정보
+     * @return 수정된 댓글 정보를 담은 AccompanyCommentResponse 객체
      */
     @Override
     @Transactional
     public AccompanyCommentResponse updateComment(Long memberId, Long commentId, AccompanyCommentRequest request) {
-        AccompanyCommentEntity comment = getComment(commentId);
+        // 댓글 엔티티 조회
+        AccompanyCommentEntity existingComment = getComment(commentId);
 
         // 댓글 작성자와 요청한 사용자가 일치하는지 확인
-        validateCommentAuthor(memberId, comment);
+        validateCommentAuthor(memberId, existingComment);
 
-        // 댓글 내용 업데이트
-        comment.setContent(request.getContent());
+        // 새 댓글 엔티티 생성 (수정된 내용 반영)
+        AccompanyCommentEntity updatedComment = AccompanyCommentEntity.builder()
+                .id(existingComment.getId()) // 기존 ID 유지
+                .memberEntity(existingComment.getMemberEntity()) // 기존 사용자 정보 유지
+                .accompanyPostEntity(existingComment.getAccompanyPostEntity()) // 기존 게시글 정보 유지
+                .content(request.getContent()) // 새 내용 반영
+                .build();
 
-        return AccompanyCommentResponse.fromEntity(accompanyCommentRepository.save(comment));
+        // 댓글 저장 및 응답 반환
+        return AccompanyCommentResponse.fromEntity(accompanyCommentRepository.save(updatedComment));
     }
+
 
     /**
      * 댓글을 삭제하는 메서드. 주어진 댓글 ID를 통해 AccompanyCommentEntity를 조회한 후, 삭제 권한이 있는지 확인하고 해당 댓글을 데이터베이스에서 삭제

--- a/src/main/java/connectripbe/connectrip_be/community/comment/entity/CommunityCommentEntity.java
+++ b/src/main/java/connectripbe/connectrip_be/community/comment/entity/CommunityCommentEntity.java
@@ -17,7 +17,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "community_comment")
@@ -39,8 +38,11 @@ public class CommunityCommentEntity extends BaseEntity {
     @JoinColumn(name = "community_post_id", nullable = false)
     private CommunityPostEntity communityPostEntity;  // 커뮤니티 아이디 (외래키)
 
-    @Setter
     @Column(nullable = false, length = 256)
     private String content;  // 내용
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 
 }

--- a/src/main/java/connectripbe/connectrip_be/community/comment/repository/CommunityCommentRepository.java
+++ b/src/main/java/connectripbe/connectrip_be/community/comment/repository/CommunityCommentRepository.java
@@ -11,4 +11,8 @@ public interface CommunityCommentRepository extends JpaRepository<CommunityComme
 
     // CommunityPostEntity 의 ID로 삭제되지 않은 댓글 목록 조회
     List<CommunityCommentEntity> findByCommunityPostEntity_IdAndDeletedAtIsNull(Long postId);
+
+    boolean existsByIdAndMemberEntity_IdAndDeletedAtIsNull(Long commentId, Long memberId);
+
+
 }

--- a/src/main/java/connectripbe/connectrip_be/community/comment/service/impl/CommunityCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/community/comment/service/impl/CommunityCommentServiceImpl.java
@@ -58,18 +58,24 @@ public class CommunityCommentServiceImpl implements CommunityCommentService {
      * @param commentId 수정할 댓글의 ID
      * @param request   수정된 댓글 내용을 포함한 요청 정보
      * @return 수정된 댓글 정보를 담은 CommunityCommentResponse 객체
+     * @throws GlobalException 수정 권한이 없는 경우 예외 발생
      */
     @Override
     @Transactional
     public CommunityCommentResponse updateComment(Long memberId, Long commentId, CommunityCommentRequest request) {
+        // 댓글 조회
         CommunityCommentEntity comment = getComment(commentId);
 
+        // 댓글 작성자와 요청자가 같은지 확인
         validateCommentAuthor(memberId, comment);
 
-        comment.setContent(request.getContent());
+        // 댓글 내용 업데이트 (setter 대신 updateContent 메서드 사용)
+        comment.updateContent(request.getContent());
 
+        // 업데이트된 댓글을 데이터베이스에 저장하고 결과 반환
         return CommunityCommentResponse.fromEntity(communityCommentRepository.save(comment));
     }
+
 
     /**
      * 댓글을 삭제하는 메서드. 주어진 댓글 ID로 댓글을 조회하고, 삭제 권한이 있는지 확인한 후 댓글을 삭제합니다.

--- a/src/main/java/connectripbe/connectrip_be/community/comment/service/impl/CommunityCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/community/comment/service/impl/CommunityCommentServiceImpl.java
@@ -63,34 +63,40 @@ public class CommunityCommentServiceImpl implements CommunityCommentService {
     @Override
     @Transactional
     public CommunityCommentResponse updateComment(Long memberId, Long commentId, CommunityCommentRequest request) {
-        // 댓글 조회
-        CommunityCommentEntity comment = getComment(commentId);
+        CommunityCommentEntity comment = communityCommentRepository.findByIdAndDeletedAtIsNull(commentId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.COMMENT_NOT_FOUND));
 
-        // 댓글 작성자와 요청자가 같은지 확인
-        validateCommentAuthor(memberId, comment);
+        if (!communityCommentRepository.existsByIdAndMemberEntity_IdAndDeletedAtIsNull(commentId, memberId)) {
+            throw new GlobalException(ErrorCode.WRITE_NOT_YOURSELF);
+        }
 
-        // 댓글 내용 업데이트 (setter 대신 updateContent 메서드 사용)
         comment.updateContent(request.getContent());
 
-        // 업데이트된 댓글을 데이터베이스에 저장하고 결과 반환
-        return CommunityCommentResponse.fromEntity(communityCommentRepository.save(comment));
+        communityCommentRepository.save(comment);
+
+        return CommunityCommentResponse.fromEntity(comment);
     }
 
 
     /**
-     * 댓글을 삭제하는 메서드. 주어진 댓글 ID로 댓글을 조회하고, 삭제 권한이 있는지 확인한 후 댓글을 삭제합니다.
+     * 댓글을 삭제하는 메서드. 주어진 댓글 ID로 댓글을 조회하고, 댓글 작성자와 현재 사용자가 일치하는지 확인한 후 삭제 처리합니다.
      *
      * @param memberId  삭제 요청자의 ID
      * @param commentId 삭제할 댓글의 ID
+     * @throws GlobalException 댓글이 존재하지 않거나 작성자가 아닌 경우 예외 발생
      */
     @Override
     @Transactional
     public void deleteComment(Long memberId, Long commentId) {
-        CommunityCommentEntity comment = getComment(commentId);
+        CommunityCommentEntity comment = communityCommentRepository.findByIdAndDeletedAtIsNull(commentId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.COMMENT_NOT_FOUND));
 
-        validateCommentAuthor(memberId, comment);
+        if (!communityCommentRepository.existsByIdAndMemberEntity_IdAndDeletedAtIsNull(commentId, memberId)) {
+            throw new GlobalException(ErrorCode.WRITE_NOT_YOURSELF);
+        }
 
         comment.deleteEntity();
+        communityCommentRepository.save(comment);
     }
 
     /**
@@ -141,17 +147,5 @@ public class CommunityCommentServiceImpl implements CommunityCommentService {
     private MemberEntity getMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_MEMBER));
-    }
-
-    /**
-     * 댓글 작성자와 요청자가 일치하는지 확인하는 메서드. 일치하지 않을 경우 예외를 발생시킵니다.
-     *
-     * @param memberId 요청자의 ID
-     * @param comment  조회된 댓글 엔티티
-     */
-    private void validateCommentAuthor(Long memberId, CommunityCommentEntity comment) {
-        if (!comment.getMemberEntity().getId().equals(memberId)) {
-            throw new GlobalException(ErrorCode.WRITE_NOT_YOURSELF);
-        }
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/community/comment/service/impl/CommunityCommentServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/community/comment/service/impl/CommunityCommentServiceImpl.java
@@ -117,17 +117,6 @@ public class CommunityCommentServiceImpl implements CommunityCommentService {
     }
 
     /**
-     * 주어진 댓글 ID로 댓글을 조회하는 메서드. 만약 해당 댓글이 존재하지 않거나 삭제된 경우 예외를 발생시킵니다.
-     *
-     * @param commentId 조회할 댓글의 ID
-     * @return 조회된 CommunityCommentEntity 객체
-     */
-    private CommunityCommentEntity getComment(Long commentId) {
-        return communityCommentRepository.findByIdAndDeletedAtIsNull(commentId)
-                .orElseThrow(() -> new GlobalException(ErrorCode.COMMENT_NOT_FOUND));
-    }
-
-    /**
      * 주어진 게시물 ID로 게시물을 조회하는 메서드. 게시물이 존재하지 않거나 삭제된 경우 예외를 발생시킵니다.
      *
      * @param postId 조회할 게시물의 ID


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] Entity에 불필요한 setter를 삭제했습니다.
- [ ] 동행 댓글 수정 날짜 부분을 수정했습니다.
- [ ] 동행 댓글 작성 부분의 request 호출 방법을 수정했습니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 동행, 커뮤니티 댓글 수정:
유지보수 효율성을 위해 Entity에 있는 setter들을 삭제하고 entity에 메서드를 추가하여 사용하도록 수정했습니다.
- 동행 댓글 수정
동행 댓글을 수정하면 createdAt이 null로 바뀌는 부분을 수정했습니다.
- 동행 댓글 작성 기능 수정:
동행 댓글 작성 부분에서 불필요하게 생성자를 생성하는 부분을 삭제했습니다. 생성자 생성이 아닌 AccompanyCommentRequest부분에 toEntity를 호출하여 사용하도록 변경했습니다.

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 