### PR TITLE
feat: 읽지 않은 메시지 확인 기능 추가

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/chat/dto/ChatUnreadMessagesResponse.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/dto/ChatUnreadMessagesResponse.java
@@ -1,0 +1,6 @@
+package connectripbe.connectrip_be.chat.dto;
+
+public record ChatUnreadMessagesResponse(
+        boolean hasUnreadMessages
+) {
+}

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
@@ -3,6 +3,7 @@ package connectripbe.connectrip_be.chat.service;
 import connectripbe.connectrip_be.chat.dto.ChatRoomEnterDto;
 import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
 import connectripbe.connectrip_be.chat.dto.ChatRoomMemberResponse;
+import connectripbe.connectrip_be.chat.dto.ChatUnreadMessagesResponse;
 import java.util.List;
 
 public interface ChatRoomService {
@@ -17,4 +18,5 @@ public interface ChatRoomService {
 
     ChatRoomEnterDto enterChatRoom(Long chatRoomId, Long memberId);
 
+    ChatUnreadMessagesResponse hasUnreadMessagesAcrossRooms(Long memberId);
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/web/ChatRoomController.java
@@ -2,6 +2,7 @@ package connectripbe.connectrip_be.chat.web;
 
 import connectripbe.connectrip_be.chat.dto.ChatRoomEnterDto;
 import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
+import connectripbe.connectrip_be.chat.dto.ChatUnreadMessagesResponse;
 import connectripbe.connectrip_be.chat.service.ChatRoomService;
 import connectripbe.connectrip_be.global.dto.GlobalResponse;
 import java.util.List;
@@ -60,5 +61,17 @@ public class ChatRoomController {
                         .body(new GlobalResponse<>("SUCCESS", chatRoomService.enterChatRoom(chatRoomId, memberId)));
 
 
+    }
+
+
+    // 채팅방 중 새로운 메시지 온다면 표시
+    @GetMapping("/new")
+    public ResponseEntity<GlobalResponse<ChatUnreadMessagesResponse>> hasUnreadMessagesAcrossRooms(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        return
+                ResponseEntity
+                        .ok()
+                        .body(new GlobalResponse<>("SUCCESS", chatRoomService.hasUnreadMessagesAcrossRooms(memberId)));
     }
 }


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 회원이 속한 모든 채팅방에서 읽지 않은 메시지가 있는지 확인하는 기능을 추가

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 회원이 속한 모든 채팅방에서 읽지 않은 메시지가 있는지 확인하는 기능을 추가했습니다.
- 새로운 API 엔드포인트(/new)를 통해 해당 기능을 제공받을 수 있습니다.
- ChatUnreadMessagesResponse DTO를 생성하여 응답 형태를 정의했습니다.
- 
### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 