### PR TITLE
fix: RateLimit 어노테이션 제거

### DIFF
--- a/src/main/java/connectripbe/connectrip_be/accompany/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/post/service/impl/AccompanyPostServiceImpl.java
@@ -17,7 +17,6 @@ import connectripbe.connectrip_be.chat.repository.ChatRoomRepository;
 import connectripbe.connectrip_be.chat.service.ChatRoomService;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
-import connectripbe.connectrip_be.global.util.bucket4j.annotation.RateLimit;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
 import connectripbe.connectrip_be.member.exception.MemberNotOwnerException;
 import connectripbe.connectrip_be.member.exception.NotFoundMemberException;
@@ -183,7 +182,6 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
 
     // 해싱을 통해 고유한 단축 URL 생성 후 Base62 인코딩
 
-    @RateLimit
     @Override
     @Transactional
     public void createAccompanyPost(Long memberId, CreateAccompanyPostRequest request) {

--- a/src/main/java/connectripbe/connectrip_be/accompany/post/service/impl/AccompanyPostServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/accompany/post/service/impl/AccompanyPostServiceImpl.java
@@ -207,7 +207,7 @@ public class AccompanyPostServiceImpl implements AccompanyPostService {
                 new AccompanyStatusEntity(post, AccompanyStatusEnum.PROGRESSING));
 
         // 채팅방 생성 및 게시물 작성자 채팅방 자동 참여 처리
-        chatRoomService.createChatRoom(post.getId(), memberId);
+        chatRoomService.createChatRoom(post, memberEntity);
     }
 
     private String generateShortUrl(String input) {

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomMemberService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomMemberService.java
@@ -1,7 +1,11 @@
 package connectripbe.connectrip_be.chat.service;
 
+import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
+import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
+
 public interface ChatRoomMemberService {
 
-    void jointChatRoom(Long chatRoomId, Long memberId);
+    ChatRoomMemberEntity jointChatRoom(ChatRoomEntity chatRoom, MemberEntity member);
 
 }

--- a/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/ChatRoomService.java
@@ -1,9 +1,11 @@
 package connectripbe.connectrip_be.chat.service;
 
+import connectripbe.connectrip_be.accompany.post.entity.AccompanyPostEntity;
 import connectripbe.connectrip_be.chat.dto.ChatRoomEnterDto;
 import connectripbe.connectrip_be.chat.dto.ChatRoomListResponse;
 import connectripbe.connectrip_be.chat.dto.ChatRoomMemberResponse;
 import connectripbe.connectrip_be.chat.dto.ChatUnreadMessagesResponse;
+import connectripbe.connectrip_be.member.entity.MemberEntity;
 import java.util.List;
 
 public interface ChatRoomService {
@@ -12,7 +14,7 @@ public interface ChatRoomService {
 
     List<ChatRoomMemberResponse> getChatRoomMembers(Long chatRoomId, Long memberId);
 
-    void createChatRoom(Long postId, Long memberId);
+    void createChatRoom(AccompanyPostEntity postEntity, MemberEntity memberEntity);
 
     void exitChatRoom(Long chatRoomId, Long id);
 

--- a/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomMemberServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/chat/service/impl/ChatRoomMemberServiceImpl.java
@@ -4,12 +4,10 @@ import connectripbe.connectrip_be.chat.entity.ChatRoomEntity;
 import connectripbe.connectrip_be.chat.entity.ChatRoomMemberEntity;
 import connectripbe.connectrip_be.chat.entity.type.ChatRoomMemberStatus;
 import connectripbe.connectrip_be.chat.repository.ChatRoomMemberRepository;
-import connectripbe.connectrip_be.chat.repository.ChatRoomRepository;
 import connectripbe.connectrip_be.chat.service.ChatRoomMemberService;
 import connectripbe.connectrip_be.global.exception.GlobalException;
 import connectripbe.connectrip_be.global.exception.type.ErrorCode;
 import connectripbe.connectrip_be.member.entity.MemberEntity;
-import connectripbe.connectrip_be.member.repository.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,29 +16,21 @@ import org.springframework.stereotype.Service;
 public class ChatRoomMemberServiceImpl implements ChatRoomMemberService {
 
     private final ChatRoomMemberRepository chatRoomMemberRepository;
-    private final ChatRoomRepository chatRoomRepository;
-    private final MemberJpaRepository memberRepository;
+
 
     /**
      * 사용자를 특정 채팅방에 참여 채팅방과 사용자가 존재하는지 확인한 후, 사용자가 이미 채팅방에 참여 중인지 확인 참여하지 않은 경우 채팅방에 사용자를 추가하고, 참여한 경우 예외를 발생
      *
-     * @param chatRoomId 참여할 채팅방의 ID
-     * @param memberId   참여할 사용자의 ID
+     * @param chatRoom 참여할 채팅방의 ID
+     * @param member   참여할 사용자의 ID
      * @throws GlobalException 채팅방이 존재하지 않거나, 사용자가 존재하지 않거나, 사용자가 이미 채팅방에 참여한 경우 발생하는 예외
      */
     @Override
-    public void jointChatRoom(Long chatRoomId, Long memberId) {
-
-        // 채팅방이 존재하는지 확인
-        ChatRoomEntity chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new GlobalException(ErrorCode.CHAT_ROOM_NOT_FOUND));
-
-        // 사용자가 존재하는지 확인
-        MemberEntity member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+    public ChatRoomMemberEntity jointChatRoom(ChatRoomEntity chatRoom, MemberEntity member) {
 
         // 이미 채팅방에 참여중인지 확인
-        boolean isMemberAlreadyInRoom = chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId);
+        boolean isMemberAlreadyInRoom = chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoom.getId(),
+                member.getId());
 
         if (isMemberAlreadyInRoom) {
             throw new GlobalException(ErrorCode.ALREADY_JOINED_CHAT_ROOM);
@@ -54,6 +44,8 @@ public class ChatRoomMemberServiceImpl implements ChatRoomMemberService {
 
         chatRoom.addChatRoomMember(chatRoomMember);
         chatRoomMemberRepository.save(chatRoomMember);
+
+        return chatRoomMember;
 
     }
 }

--- a/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
+++ b/src/main/java/connectripbe/connectrip_be/pending_list/service/impl/PendingListServiceImpl.java
@@ -157,7 +157,7 @@ public class PendingListServiceImpl implements PendingListService {
                                 member)
                         .orElseThrow(() -> new GlobalException(ErrorCode.PENDING_NOT_FOUND));
 
-                // 상태가 DEFAULT라면 PENDING으로 업데이트
+                // 상태가 DEFAULT 라면 PENDING 으로 업데이트
                 if (existingPending.getStatus().equals(PendingStatus.DEFAULT)) {
                     existingPending.updateStatus(PendingStatus.PENDING);
                     pendingListRepository.save(existingPending);
@@ -203,7 +203,7 @@ public class PendingListServiceImpl implements PendingListService {
         ChatRoomEntity chatRoom = chatRoomRepository.findByAccompanyPost_Id(accompanyPostId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.CHATROOM_NOT_FOUND));
 
-        chatRoomMemberService.jointChatRoom(chatRoom.getId(), memberId);
+        chatRoomMemberService.jointChatRoom(chatRoom, member);
 
         return PendingResponse.builder()
                 .status(pending.getStatus().toString())
@@ -211,7 +211,7 @@ public class PendingListServiceImpl implements PendingListService {
     }
 
     /**
-     * 사용자의 동행 신청을 거절합니다. 신청 상태를 REJECTED로 변경합니다.
+     * 사용자의 동행 신청을 거절합니다. 신청 상태를 REJECTED 로 변경합니다.
      *
      * @param memberId        거절할 사용자의 ID
      * @param accompanyPostId 신청한 게시물의 ID


### PR DESCRIPTION
createAccompanyPost 메소드에서 RateLimit 어노테이션을 제거했습니다.

### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ ] 

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
-

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
-

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 